### PR TITLE
Less greedy charset matching

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -115,7 +115,7 @@ Response.prototype._convert = function(encoding) {
 
 	// header
 	if (this.headers.has('content-type')) {
-		res = /charset=(.*)/i.exec(this.headers.get('content-type'));
+		res = /charset=([^;]*)/i.exec(this.headers.get('content-type'));
 	}
 
 	// no charset in content type, peek at response body


### PR DESCRIPTION
We're currently getting 

```[Error: Encoding not recognized: 'UTF-8; QS=1' (searched as: 'utf8qs1')]```

errors when using `node-fetch`, due to our `Content-Type` response header having the value 

```application/json; charset=UTF-8; qs=1```,

 i.e. a value after the `charset`

This PR just makes the charset extraction less greedy, so stop on a semi-colon