### PR TITLE
Throw instead of ignore, if headers are invalid

### DIFF
--- a/lib/headers.js
+++ b/lib/headers.js
@@ -32,11 +32,9 @@ function Headers(headers) {
 		if (typeof headers[prop] === 'string') {
 			this.set(prop, headers[prop]);
 		} else if (headers[prop] instanceof Array) {
-			if (headers[prop].length > 0) {
-				headers[prop].forEach(function(item) {
-					self.append(prop, item);
-				});
-			} else continue;
+			headers[prop].forEach(function(item) {
+				self.append(prop, item);
+			});
 		} else {
 			throw new Error('invalid header "' + prop +
 				'" (value must must be of type string)')

--- a/lib/headers.js
+++ b/lib/headers.js
@@ -31,10 +31,15 @@ function Headers(headers) {
 
 		if (typeof headers[prop] === 'string') {
 			this.set(prop, headers[prop]);
-		} else if (headers[prop].length > 0) {
-			headers[prop].forEach(function(item) {
-				self.append(prop, item);
-			});
+		} else if (typeof headers[prop] === 'object') {
+			if (headers[prop].length > 0) {
+				headers[prop].forEach(function(item) {
+					self.append(prop, item);
+				});
+			} else continue;
+		} else {
+			throw new Error('invalid header "' + prop +
+				'" (value must must be of type string)')
 		}
 	}
 

--- a/test/test.js
+++ b/test/test.js
@@ -154,6 +154,14 @@ describe('node-fetch', function() {
 		});
 	});
 
+	it('should reject invalid headers', function() {
+		var fn = function() {
+			return new Headers({ 'content-length': 100 });
+		}
+		return expect(fn).to.throw('invalid header "content-length" ' +
+			'(value must must be of type string)');
+	});
+
 	it('should follow redirect code 301', function() {
 		url = base + '/redirect/301';
 		return fetch(url).then(function(res) {


### PR DESCRIPTION
After spending on hour trying to debug the problem, I found out that I was passing a number as header value, thus the header was ignored. 

I think it would be much more useful throwing an error if something is not valid, instead of silently ignore it.

Thanks