### PR TITLE
Use iconv directly instead of encoding library

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -6,7 +6,7 @@
  */
 
 var http = require('http');
-var convert = require('encoding').convert;
+var iconvLite = require('iconv-lite');
 
 module.exports = Response;
 
@@ -166,11 +166,7 @@ Response.prototype._convert = function(encoding) {
 	}
 
 	// turn raw buffers into utf-8 string
-	return convert(
-		Buffer.concat(this._raw)
-		, encoding
-		, charset
-	).toString();
+	return iconvLite.decode(Buffer.concat(this._raw), charset);
 
 }
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "resumer": "0.0.0"
   },
   "dependencies": {
-    "encoding": "^0.1.11"
+    "iconv-lite": "^0.4.8"
   }
 }

--- a/test/server.js
+++ b/test/server.js
@@ -3,7 +3,7 @@ var http = require('http');
 var parse = require('url').parse;
 var zlib = require('zlib');
 var stream = require('stream');
-var convert = require('encoding').convert;
+var iconvLite = require('iconv-lite');
 
 module.exports = TestServer;
 
@@ -122,25 +122,25 @@ TestServer.prototype.router = function(req, res) {
 	if (p === '/encoding/gbk') {
 		res.statusCode = 200;
 		res.setHeader('Content-Type', 'text/html');
-		res.end(convert('<meta charset="gbk"><div>中文</div>', 'gbk'));
+		res.end(iconvLite.encode('<meta charset="gbk"><div>中文</div>', 'gbk'));
 	}
 
 	if (p === '/encoding/gb2312') {
 		res.statusCode = 200;
 		res.setHeader('Content-Type', 'text/html');
-		res.end(convert('<meta http-equiv="Content-Type" content="text/html; charset=gb2312"><div>中文</div>', 'gb2312'));
+		res.end(iconvLite.encode('<meta http-equiv="Content-Type" content="text/html; charset=gb2312"><div>中文</div>', 'gb2312'));
 	}
 
 	if (p === '/encoding/shift-jis') {
 		res.statusCode = 200;
 		res.setHeader('Content-Type', 'text/html; charset=Shift-JIS');
-		res.end(convert('<div>日本語</div>', 'Shift_JIS'));
+		res.end(iconvLite.encode('<div>日本語</div>', 'Shift_JIS'));
 	}
 
 	if (p === '/encoding/euc-jp') {
 		res.statusCode = 200;
 		res.setHeader('Content-Type', 'text/xml');
-		res.end(convert('<?xml version="1.0" encoding="EUC-JP"?><title>日本語</title>', 'EUC-JP'));
+		res.end(iconvLite.encode('<?xml version="1.0" encoding="EUC-JP"?><title>日本語</title>', 'EUC-JP'));
 	}
 
 	if (p === '/encoding/utf8') {
@@ -151,13 +151,13 @@ TestServer.prototype.router = function(req, res) {
 	if (p === '/encoding/order1') {
 		res.statusCode = 200;
 		res.setHeader('Content-Type', 'charset=gbk; text/plain');
-		res.end(convert('中文', 'gbk'));
+		res.end(iconvLite.encode('中文', 'gbk'));
 	}
 
 	if (p === '/encoding/order2') {
 		res.statusCode = 200;
 		res.setHeader('Content-Type', 'text/plain; charset=gbk; qs=1');
-		res.end(convert('中文', 'gbk'));
+		res.end(iconvLite.encode('中文', 'gbk'));
 	}
 
 	if (p === '/redirect/301') {


### PR DESCRIPTION
**tl;dr** Drops `encoding` and favours `iconv-lite` to be able to bundle it with (e.g.: `webpack`, `browserify`) without problems.


Currently, if I bundle `node-fetch` with `webpack` I get a warning that `encoding` is using dynamic dependencies. Unfortunately the guy from the `encoding` library explained that there is no way around it.
He then suggested though to actually use directly `iconv`. Tests are still working of course.

You can follow the conversations about this problem here:
https://github.com/andris9/encoding/pull/13
https://github.com/webpack/webpack/issues/918#issuecomment-98640907

Hope it's ok for you :)