### PR TITLE
Allow a custom host to be set

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,11 @@ function Fetch(url, opts) {
 
 		options.headers = headers.raw();
 
+		// HACK: headers.host must be a string, cannot be an array otherwise get error ‘undefined is not a function’
+		if (options.headers.host) {
+			options.headers.host = options.headers.host[0];
+		}
+
 		// send request
 		var req = send(options);
 		var reqTimeout;

--- a/test/server.js
+++ b/test/server.js
@@ -244,4 +244,10 @@ TestServer.prototype.router = function(req, res) {
 		});
 	}
 
+	if (p === '/host') {
+		res.statusCode = 200;
+		res.setHeader('Fetch-Sent-Host', req.headers.host);
+		res.end();
+	}
+
 }

--- a/test/test.js
+++ b/test/test.js
@@ -751,4 +751,18 @@ describe('node-fetch', function() {
 			expect(res.ok).to.be.true;
 		});
 	});
+
+	it('should allow setting of custom host', function() {
+		url = base + '/host';
+		opts = {
+			method: 'HEAD',
+			headers: {
+				host: 'bitinn.net'
+			}
+		};
+		return fetch(url, opts).then(function(res) {
+			expect(res.headers.get('fetch-sent-host')).to.equal('bitinn.net');
+		});
+	});
+
 });


### PR DESCRIPTION
Some of the requests we make from the server need to overwrite the host header (e.g. for ‘apis’ which were originally written with a CDN in mind and we're just making requests that act like a CDN) and node-fetch currently chokes if you try to set a custom host header, check out e98f22b3ba8350a37c6f3c8917df56655e5c4fc7, run `npm test` and you'll get this output:-

```
  1) node-fetch should allow setting of custom host:
     TypeError: undefined is not a function
      at Agent.createSocket (_http_agent.js:186:39)
      at Agent.addRequest (_http_agent.js:166:23)
      at new ClientRequest (_http_client.js:154:16)
      at exports.request (http.js:49:10)
      at /Users/mandrews/sandboxes/node-fetch/index.js:83:13
      at new Fetch (/Users/mandrews/sandboxes/node-fetch/index.js:44:9)
      at Fetch (/Users/mandrews/sandboxes/node-fetch/index.js:32:10)
      at Context.<anonymous> (/Users/mandrews/sandboxes/node-fetch/test/test.js:763:10)
      at callFn (/Users/mandrews/sandboxes/node-fetch/node_modules/mocha/lib/runnable.js:251:21)
      at Test.Runnable.run (/Users/mandrews/sandboxes/node-fetch/node_modules/mocha/lib/runnable.js:244:7)
      at Runner.runTest (/Users/mandrews/sandboxes/node-fetch/node_modules/mocha/lib/runner.js:374:10)
      at /Users/mandrews/sandboxes/node-fetch/node_modules/mocha/lib/runner.js:452:12
      at next (/Users/mandrews/sandboxes/node-fetch/node_modules/mocha/lib/runner.js:299:14)
      at /Users/mandrews/sandboxes/node-fetch/node_modules/mocha/lib/runner.js:309:7
      at next (/Users/mandrews/sandboxes/node-fetch/node_modules/mocha/lib/runner.js:248:23)
      at Immediate._onImmediate (/Users/mandrews/sandboxes/node-fetch/node_modules/mocha/lib/runner.js:276:5)
      at processImmediate [as _immediateCallback] (timers.js:358:17)
```

I'm not entirely happy with my hack but it seemed the least intrusive way to make this work :disappointed:.  Very happy to tweak the implementation if you can think of a better way.