### PR TITLE
Expose ‘keepAlive’ option

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ default values are shown, note that only `method`, `headers` and `body` are allo
 	, size: 0         // maximum response body size in bytes, 0 to disable
 	, body: empty     // request body, can be a string or readable stream
 	, agent: null     // custom http.Agent instance
+	, keepAlive: null // keep sockets around in a pool to be used by other requests in the future
 }
 ```
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -57,6 +57,7 @@ function Request(input, init) {
 		input.compress : true;
 	this.size = init.size || input.size || 0;
 	this.agent = init.agent || input.agent;
+	this.keepAlive = init.keepAlive || input.keepAlive;
 
 	// server request options
 	this.protocol = url_parsed.protocol;


### PR DESCRIPTION
Hi @bitinn, I wonder if you'd consider exposing the `keepAlive` option to `http.request`/`https.request`?

https://nodejs.org/api/http.html#http_http_request_options_callback
https://nodejs.org/api/https.html#https_https_request_options_callback