### PR TITLE
Automatically pull headers from node-form-data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ fetch('http://httpbin.org/post', { method: 'POST', body: stream })
 var FormData = require('form-data');
 var form = new FormData();
 form.append('a', 1);
-fetch('http://httpbin.org/post', { method: 'POST', body: form, headers: form.getHeaders() })
+fetch('http://httpbin.org/post', { method: 'POST', body: form })
 	.then(function(res) {
 		return res.json();
 	}).then(function(json) {

--- a/index.js
+++ b/index.js
@@ -77,6 +77,10 @@ function Fetch(url, opts) {
 			headers.set('accept', '*/*');
 		}
 
+		if (!headers.has('content-type') && options.body && typeof options.body.getBoundary === "function") {
+			headers.set('content-type', 'multipart/form-data; boundary=' + options.body.getBoundary());
+		}
+
 		options.headers = headers.raw();
 
 		// http.request only support string as host header, this hack make custom host header possible

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "chai": "^1.10.0",
     "chai-as-promised": "^4.1.1",
     "coveralls": "^2.11.2",
+    "form-data": "^1.0.0-rc1",
     "istanbul": "^0.3.5",
     "mocha": "^2.1.0",
     "promise": "^6.1.0",

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,7 @@ var then = require('promise');
 var spawn = require('child_process').spawn;
 var stream = require('stream');
 var resumer = require('resumer');
+var FormData = require('form-data');
 
 var TestServer = require('./server');
 
@@ -445,6 +446,25 @@ describe('node-fetch', function() {
 			expect(res.body).to.equal('a=1');
 		});
 	});
+
+	it('should allow POST request with form-data as body', function() {
+		var form = new FormData();
+		form.append('a', '1');
+
+		url = base + '/inspect';
+		opts = {
+			method: 'POST'
+			, body: form
+		};
+		return fetch(url, opts).then(function(res) {
+			return res.json();
+		}).then(function(res) {
+			expect(res.method).to.equal('POST');
+			expect(res.body).to.contain('Content-Disposition: form-data;')
+				.and.to.contain('name="a"');
+		});
+	});
+
 
 	it('should allow PUT request', function() {
 		url = base + '/inspect';


### PR DESCRIPTION
This is convenient for isomorphic apps that rely on form-data.