### PR TITLE
Detect encoding from meta charset at large header

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -140,7 +140,7 @@ Response.prototype._convert = function(encoding) {
 
 	// no charset in content type, peek at response body
 	if (!res && this._raw.length > 0) {
-		str = this._raw[0].toString().substr(0, 1024);
+		str = this._raw.slice(0,4).join('').substr(0, 1024*2);
 	}
 
 	// html5

--- a/lib/response.js
+++ b/lib/response.js
@@ -140,7 +140,17 @@ Response.prototype._convert = function(encoding) {
 
 	// no charset in content type, peek at response body
 	if (!res && this._raw.length > 0) {
-		str = this._raw.slice(0,4).join('').substr(0, 1024*2);
+		if (this.headers.get('transfer-encoding') === 'chunked') {
+			var buf, index = 0, length = 0;
+			while(length < 1024 && (buf = this._raw[index])) {
+				length += buf.length;
+				index++;
+			}
+			str = this._raw.slice(0,index).join('');
+		} else {
+			str = this._raw[0].toString();
+		}
+		str = str.substr(0, 1024);
 	}
 
 	// html5

--- a/test/server.js
+++ b/test/server.js
@@ -145,33 +145,31 @@ TestServer.prototype.router = function(req, res) {
 		res.end(convert('<div>日本語</div>', 'Shift_JIS'));
 	}
 
-	if (p === '/encoding/large-shift-jis') {
+	if (p === '/encoding/chunked') {
 		res.statusCode = 200;
 		res.setHeader('Content-Type', 'text/html');
 		res.setHeader('Transfer-Encoding', 'chunked');
 		var html = [
 			'<!DOCTYPE HTML>',
 			'<html lang="ja" xmlns="http://www.w3.org/1999/xhtml" xmlns:og="http://ogp.me/ns#" xmlns:fb="https://www.facebook.com/2008/fbml">',
-			'<head>',
+			'<head><meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS" />',
 			'<meta http-equiv="X-UA-Compatible" content="IE=edge" />',
 			'<meta name="author" content="テスト" />',
 			'<meta name="copyright" content="Copyright &copy; Sample Corporation. All Rights Reserved." />',
 			'<title>テスト用サンプル タイトル</title>',
-			'<meta name="description" content="これはテスト用のDescriptionです">',
-			'<meta name="keywords" content="キーワード" />',
-			'<meta name="target-year" content="2015" />',
-			'<meta property="og:title" content="サンプル タイル" />',
-			'<meta property="og:type" content="article" />',
-			'<meta property="og:url" content="http://example.com/test.html" />',
-			'<meta property="og:image" content="http://example.com/test.png" />',
-			'<meta property="og:description" content="これはテスト用のDescriptionです" />',
-			'<meta property="og:locale" content="ja_JP" />',
-			'<meta property="og:site_name" content="Sample" />',
-			'<link rel="canonical" href="http://example.com/test.html" />',
-			'<link rel="stylesheet" href="/css.css">',
-			'<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS" />',
-		].join('');
-		res.end(convert(html, 'Shift_JIS'));
+		];
+		var encoding = 'Shift_JIS';
+		function writeHtmlCunk(index) {
+			index = index || 0;
+			return function() {
+				if (index < html.length - 1) {
+					res.write(html[index], writeHtmlCunk(++index));
+				} else {
+					res.end(convert(html[index], 'Shift_JIS'));
+				}
+			};
+		}
+		writeHtmlCunk()();
 	}
 
 	if (p === '/encoding/euc-jp') {

--- a/test/server.js
+++ b/test/server.js
@@ -145,6 +145,35 @@ TestServer.prototype.router = function(req, res) {
 		res.end(convert('<div>日本語</div>', 'Shift_JIS'));
 	}
 
+	if (p === '/encoding/large-shift-jis') {
+		res.statusCode = 200;
+		res.setHeader('Content-Type', 'text/html');
+		res.setHeader('Transfer-Encoding', 'chunked');
+		var html = [
+			'<!DOCTYPE HTML>',
+			'<html lang="ja" xmlns="http://www.w3.org/1999/xhtml" xmlns:og="http://ogp.me/ns#" xmlns:fb="https://www.facebook.com/2008/fbml">',
+			'<head>',
+			'<meta http-equiv="X-UA-Compatible" content="IE=edge" />',
+			'<meta name="author" content="テスト" />',
+			'<meta name="copyright" content="Copyright &copy; Sample Corporation. All Rights Reserved." />',
+			'<title>テスト用サンプル タイトル</title>',
+			'<meta name="description" content="これはテスト用のDescriptionです">',
+			'<meta name="keywords" content="キーワード" />',
+			'<meta name="target-year" content="2015" />',
+			'<meta property="og:title" content="サンプル タイル" />',
+			'<meta property="og:type" content="article" />',
+			'<meta property="og:url" content="http://example.com/test.html" />',
+			'<meta property="og:image" content="http://example.com/test.png" />',
+			'<meta property="og:description" content="これはテスト用のDescriptionです" />',
+			'<meta property="og:locale" content="ja_JP" />',
+			'<meta property="og:site_name" content="Sample" />',
+			'<link rel="canonical" href="http://example.com/test.html" />',
+			'<link rel="stylesheet" href="/css.css">',
+			'<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS" />',
+		].join('');
+		res.end(convert(html, 'Shift_JIS'));
+	}
+
 	if (p === '/encoding/euc-jp') {
 		res.statusCode = 200;
 		res.setHeader('Content-Type', 'text/xml');

--- a/test/test.js
+++ b/test/test.js
@@ -658,8 +658,8 @@ describe('node-fetch', function() {
 		});
 	});
 
-	it('should support encoding decode, meta charset detect at large header', function() {
-		url = base + '/encoding/large-shift-jis';
+	it('should support encoding decode, meta charset detect with chunked data', function() {
+		url = base + '/encoding/chunked';
 		return fetch(url).then(function(res) {
 			expect(res.status).to.equal(200);
 			return res.text().then(function(result) {

--- a/test/test.js
+++ b/test/test.js
@@ -658,6 +658,17 @@ describe('node-fetch', function() {
 		});
 	});
 
+	it('should support encoding decode, meta charset detect at large header', function() {
+		url = base + '/encoding/large-shift-jis';
+		return fetch(url).then(function(res) {
+			expect(res.status).to.equal(200);
+			return res.text().then(function(result) {
+				expect(result).to.match(/テスト用サンプル タイトル/);
+			});
+		});
+	});
+
+
 	it('should support encoding decode, html5 detect', function() {
 		url = base + '/encoding/gbk';
 		return fetch(url).then(function(res) {


### PR DESCRIPTION
If the meta tag is in the back of the head, charset,  it is not possible to correctly determine the charset.
