### PR TITLE
Added convenience methods .json() and .text() to the promise returned…

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function Fetch(url, opts) {
 	var self = this;
 
 	// wrap http.request into fetch
-	return new Fetch.Promise(function(resolve, reject) {
+	return decorate(new Fetch.Promise(function(resolve, reject) {
 		// build request object
 		var options;
 		try {
@@ -182,9 +182,28 @@ function Fetch(url, opts) {
 		} else {
 			req.end();
 		}
-	});
+	}));
 
 };
+
+/**
+ * Adds convenience methods to the promise:
+ * .json() & .text()
+ */
+function decorate(fetchPromise) {
+	fetchPromise.json = function() {
+		return fetchPromise.then(function (res) {
+			return res.json()
+		})
+	}
+
+	fetchPromise.text = function() {
+		return fetchPromise.then(function (res) {
+			return res.text()
+		})
+	}
+	return fetchPromise
+}
 
 /**
  * Redirect code matching

--- a/test/test.js
+++ b/test/test.js
@@ -904,4 +904,20 @@ describe('node-fetch', function() {
 		});
 	});
 
+	it('should support the .text() convenience method', function() {
+		this.timeout(5000);
+		return fetch('http://jsonplaceholder.typicode.com/users').text().then(function(text) {
+			expect(text).to.be.a('string')
+			expect(text).to.satisfy(function(s) { return s.length > 0 })
+		})
+	});
+
+	it('should support the .json() convenience method', function() {
+		this.timeout(5000);
+		return fetch('http://jsonplaceholder.typicode.com/users').json().then(function(users) {
+			expect(users).to.be.instanceof(Array)
+			expect(users[0].id).to.equal(1)
+		})
+	});
+
 });

--- a/test/test.js
+++ b/test/test.js
@@ -906,17 +906,17 @@ describe('node-fetch', function() {
 
 	it('should support the .text() convenience method', function() {
 		this.timeout(5000);
-		return fetch('http://jsonplaceholder.typicode.com/users').text().then(function(text) {
+		return fetch(base + '/hello').text().then(function(text) {
 			expect(text).to.be.a('string')
-			expect(text).to.satisfy(function(s) { return s.length > 0 })
+			expect(text).to.equal('world')
 		})
 	});
 
 	it('should support the .json() convenience method', function() {
 		this.timeout(5000);
-		return fetch('http://jsonplaceholder.typicode.com/users').json().then(function(users) {
-			expect(users).to.be.instanceof(Array)
-			expect(users[0].id).to.equal(1)
+		return fetch(base + '/json').json().then(function(json) {
+			expect(json).to.be.a('object')
+			expect(json.name).to.equal('value')
 		})
 	});
 


### PR DESCRIPTION
Added convenience methods .json() and .text() to the promise returned by fetch()

This allows for (compacted) calls such as:

fetch('http://example/').text()
.then(theText => console.log(theText))
