### PR TITLE
Add content-length header with form-data

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,9 @@ function Fetch(url, opts) {
 		if (!headers.has('content-length') && options.method.substr(0, 1).toUpperCase() === 'P') {
 			if (typeof options.body === 'string') {
 				headers.set('content-length', Buffer.byteLength(options.body));
+			// detect form data input from form-data module, this hack avoid the need to add content-length header manually
+			} else if (options.body && typeof options.body.getLengthSync === 'function') {
+				headers.set('content-length', options.body.getLengthSync().toString());
 			// this is only necessary for older nodejs releases (before iojs merge)
 			} else if (options.body === undefined || options.body === null) {
 				headers.set('content-length', '0');


### PR DESCRIPTION
Old source do not add content-length header automatically
with form-data. If body is instance of form-data, Users
must missing this header. It cause parse error with some
server engine like WSGI. WSGI must drop body if this was not
set, and WSGI based frameworks such as flask can not read
form data.

For example, this python code with flask..

```py
from flask import Flask, request, jsonify

app = Flask(__name__)

@app.route('/', method=['POST'])
def index():
    return jsonify(**request.form)

app.run()
```

Can not receive any data from this code.

```js
require('es6-promise').polyfill();
var fetch = require('isomorphic-fetch'); // it use node-fetch
var FormData = require('form-data');

var data = new FormData();
data.append('name', 'item4');
data.append('message', 'it is test!');
fetch('http://localhost:5000', {method: 'POST', body: data})
  .then(function (data) {
    return data.json();
  })
  .then(function (data) {
    console.log(data);
  });
```

This commit just use FormData's getLengthSync method.