### PR TITLE
added support for rejectUnauthorized option

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -47,6 +47,8 @@ function Request(input, init) {
 	this.body = init.body || input.body;
 	this.url = url;
 
+	this.rejectUnauthorized = init.rejectUnauthorized !== undefined ? init.rejectUnauthorized : true;
+
 	// server only options
 	this.follow = init.follow !== undefined ?
 		init.follow : input.follow !== undefined ?


### PR DESCRIPTION
Was running into SSL certificate issues for certain requests (unable to verify the first certificate).

The standard https library has an option to ignore this (setting the rejectUnauthorized option to false).

This pull request enables you to pass that rejectUnauthorized option.