### PR TITLE
Support being able to extract the ‘location’ header from redirected HTTP requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "iojs"
   - "node"
+  - "4"
+  - "5"
 before_install: npm install -g npm
 script: npm run coverage

--- a/test/test.js
+++ b/test/test.js
@@ -927,4 +927,24 @@ describe('node-fetch', function() {
 		});
 	});
 
+	it('should throw when maximum redirect count reached', function() {
+		url = base + '/redirect/301';
+		return fetch(url, { follow: 0 }).then(function() {
+			throw new Error("Promise should not resolve");
+		}, function(err) {
+			expect(err.toString()).to.contain('maximum redirect reached');
+		});
+	});
+
+	it('should not throw when maximum redirect count reached and throwOnMaximumRedirect: false', function() {
+		url = base + '/redirect/301';
+		return fetch(url, {
+			follow: 0,
+			throwOnMaximumRedirect: false
+		}).then(function(res) {
+			expect(res.status).to.eql(301);
+			expect(res.headers.get('location')).to.eql('/inspect');
+		});
+	});
+
 });


### PR DESCRIPTION
What do you think about this?

At the moment we're currently doing this:- 

```js
return shellpromise(`curl -s http://www.ft.com/fastft/?p=${id} -I -H 'X-FT-Access-Metadata: remote_headers' | grep -i location`)
	.then(loc => {
		return loc
			.replace(/location\:/i, '')
			.trim();
	});
```

It would be nice if `node-fetch` supported this use case.

Apologies that the API is so unwieldy.  Very happy to change `throwOnMaximumRedirect` to something more succinct.  Also I will update the docs before this should get merged.

I also added a test that explicitly checked the current behaviour.

cc @wheresrhys 