### PR TITLE
Add buffer method to Response. Resolves #51

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -41,7 +41,7 @@ function Response(body, opts) {
  */
 Response.prototype.json = function() {
 
-	return this._decode().then(function(text) {
+	return this.text().then(function(text) {
 		return JSON.parse(text);
 	});
 
@@ -54,16 +54,70 @@ Response.prototype.json = function() {
  */
 Response.prototype.text = function() {
 
-	return this._decode();
+	var self = this;
+	return this.buffer().then(function(buffer) {
 
+		// Detect buffer encoding and convert to target encoding
+		// ref: http://www.w3.org/TR/2011/WD-html5-20110113/parsing.html#determining-the-character-encoding
+
+		var charset = 'utf-8';
+		var res, str;
+
+		// header
+		if (self.headers.has('content-type')) {
+			res = /charset=([^;]*)/i.exec(self.headers.get('content-type'));
+		}
+
+		// no charset in content type, peek at response body
+		if (!res && buffer.length > 0) {
+			str = buffer.toString(null, 0, 1024);
+		}
+
+		// html5
+		if (!res && str) {
+			res = /<meta.+?charset=(['"])(.+?)\1/i.exec(str);
+		}
+
+		// html4
+		if (!res && str) {
+			res = /<meta[\s]+?http-equiv=(['"])content-type\1[\s]+?content=(['"])(.+?)\2/i.exec(str);
+
+			if (res) {
+				res = /charset=(.*)/i.exec(res.pop());
+			}
+		}
+
+		// xml
+		if (!res && str) {
+			res = /<\?xml.+?encoding=(['"])(.+?)\1/i.exec(str);
+		}
+
+		// found charset
+		if (res) {
+			charset = res.pop();
+
+			// prevent decode issues when sites use incorrect encoding
+			// ref: https://hsivonen.fi/encoding-menu/
+			if (charset === 'gb2312' || charset === 'gbk') {
+				charset = 'gb18030';
+			}
+		}
+
+		// turn raw buffers into utf-8 string
+		return convert(
+			buffer
+			, 'utf-8'
+			, charset
+		).toString();
+	})
 }
 
 /**
- * Decode buffers into utf-8 string
+ * Read body into buffer
  *
  * @return  Promise
  */
-Response.prototype._decode = function() {
+Response.prototype.buffer = function() {
 
 	var self = this;
 
@@ -113,74 +167,11 @@ Response.prototype._decode = function() {
 			}
 
 			clearTimeout(resTimeout);
-			resolve(self._convert());
+			resolve(Buffer.concat(self._raw));
 		});
 	});
 
 };
-
-/**
- * Detect buffer encoding and convert to target encoding
- * ref: http://www.w3.org/TR/2011/WD-html5-20110113/parsing.html#determining-the-character-encoding
- *
- * @param   String  encoding  Target encoding
- * @return  String
- */
-Response.prototype._convert = function(encoding) {
-
-	encoding = encoding || 'utf-8';
-
-	var charset = 'utf-8';
-	var res, str;
-
-	// header
-	if (this.headers.has('content-type')) {
-		res = /charset=([^;]*)/i.exec(this.headers.get('content-type'));
-	}
-
-	// no charset in content type, peek at response body
-	if (!res && this._raw.length > 0) {
-		str = this._raw[0].toString().substr(0, 1024);
-	}
-
-	// html5
-	if (!res && str) {
-		res = /<meta.+?charset=(['"])(.+?)\1/i.exec(str);
-	}
-
-	// html4
-	if (!res && str) {
-		res = /<meta[\s]+?http-equiv=(['"])content-type\1[\s]+?content=(['"])(.+?)\2/i.exec(str);
-
-		if (res) {
-			res = /charset=(.*)/i.exec(res.pop());
-		}
-	}
-
-	// xml
-	if (!res && str) {
-		res = /<\?xml.+?encoding=(['"])(.+?)\1/i.exec(str);
-	}
-
-	// found charset
-	if (res) {
-		charset = res.pop();
-
-		// prevent decode issues when sites use incorrect encoding
-		// ref: https://hsivonen.fi/encoding-menu/
-		if (charset === 'gb2312' || charset === 'gbk') {
-			charset = 'gb18030';
-		}
-	}
-
-	// turn raw buffers into utf-8 string
-	return convert(
-		Buffer.concat(this._raw)
-		, encoding
-		, charset
-	).toString();
-
-}
 
 // expose Promise
 Response.Promise = global.Promise;

--- a/test/server.js
+++ b/test/server.js
@@ -55,6 +55,12 @@ TestServer.prototype.router = function(req, res) {
 		}));
 	}
 
+	if (p === '/buffer') {
+		res.statusCode = 200;
+		res.setHeader('Content-Type', 'application/octet-stream');
+		res.end(new Buffer([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]));
+	}
+
 	if (p === '/gzip') {
 		res.statusCode = 200;
 		res.setHeader('Content-Type', 'text/plain');

--- a/test/test.js
+++ b/test/test.js
@@ -138,6 +138,18 @@ describe('node-fetch', function() {
 		});
 	});
 
+	it('should accept buffer response', function() {
+		url = base + '/buffer';
+		return fetch(url).then(function(res) {
+			expect(res.headers.get('content-type')).to.equal('application/octet-stream');
+			return res.buffer().then(function(result) {
+				expect(res.bodyUsed).to.be.true;
+				expect(result).to.be.an('object');
+				expect(result).to.deep.equal(new Buffer([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]));
+			});
+		});
+	});
+
 	it('should send request with custom headers', function() {
 		url = base + '/inspect';
 		opts = {


### PR DESCRIPTION
This patch add support for accessing the response body stream as a Buffer.
This is similar to arrayBuffer, but in nodejs style.

Use cases:

```javascript
fetch('http://.../Some.TV.Show.S01E01.FeTCH.smi')
    .then(function(res) {
        return res.buffer();
    }).then(function(buffer) {
        var smi = convert(buffer, 'utf-8', 'CP949').toString();
        ...
    });


fetch('http://.../Some.TV.Show.S01E01.FeTCH.sub')
    .then(function(res) {
        return res.buffer();
    }).then(function(buffer) {
        var charset;
        var subType;
        
        if (buffer[0] == 0xef && buffer[1] == 0xbb && buffer[2] == 0xbf) {
            charset = 'utf8';
            buffer = buffer.slice(3);
        }
        if (buffer[0] == '1')
            subType = 'srt';
        else if (buffer[0] == '<' && buffer[1] == 'S')
            subType = 'smi';
        else
            ...
            
        var sub = convert(buffer, 'utf-8', charset).toString();
        ...
    });
```
