### PR TITLE
Add string body support to Response

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -88,33 +88,37 @@ Response.prototype._decode = function() {
 		}
 
 		// handle stream error, such as incorrect content-encoding
-		self.body.on('error', function(err) {
-			reject(new Error('invalid response body at: ' + self.url + ' reason: ' + err.message));
-		});
+		if (typeof self.body === 'string') {
+			resolve(self.body);
+		} else {
+			self.body.on('error', function(err) {
+				reject(new Error('invalid response body at: ' + self.url + ' reason: ' + err.message));
+			});
 
-		self.body.on('data', function(chunk) {
-			if (self._abort || chunk === null) {
-				return;
-			}
+			self.body.on('data', function(chunk) {
+				if (self._abort || chunk === null) {
+					return;
+				}
 
-			if (self.size && self._bytes + chunk.length > self.size) {
-				self._abort = true;
-				reject(new Error('content size at ' + self.url + ' over limit: ' + self.size));
-				return;
-			}
+				if (self.size && self._bytes + chunk.length > self.size) {
+					self._abort = true;
+					reject(new Error('content size at ' + self.url + ' over limit: ' + self.size));
+					return;
+				}
 
-			self._bytes += chunk.length;
-			self._raw.push(chunk);
-		});
+				self._bytes += chunk.length;
+				self._raw.push(chunk);
+			});
 
-		self.body.on('end', function() {
-			if (self._abort) {
-				return;
-			}
+			self.body.on('end', function() {
+				if (self._abort) {
+					return;
+				}
 
-			clearTimeout(resTimeout);
-			resolve(self._convert());
-		});
+				clearTimeout(resTimeout);
+				resolve(self._convert());
+			});
+		}
 	});
 
 };

--- a/test/test.js
+++ b/test/test.js
@@ -904,6 +904,15 @@ describe('node-fetch', function() {
 		});
 	});
 
+	it('should support strings as a response body', function() {
+		var body = '{"id": 1}';
+		var res = new Response(body);
+
+		return res.json().then(function(result) {
+			expect(result.id).to.equal(1);
+		});
+	});
+
 	it('should support parsing headers in Request constructor', function() {
 		url = base;
 		var req = new Request(url, {


### PR DESCRIPTION
This adds support to pass in a string value to `Response` instead of
always expecting a pipe. This makes `Response` more compatible with the
spec as well as making it easier to construct a manual `Response`
object.