### PR TITLE
Reject fetch promise with actual request error

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ function Fetch(url, opts) {
 
 		req.on('error', function(err) {
 			clearTimeout(reqTimeout);
-			reject(new Error('request to ' + options.url + ' failed, reason: ' + err.message));
+			reject(err);
 		});
 
 		req.on('response', function(res) {


### PR DESCRIPTION
The real request error has valuable fields such as `code` and `stack`, but these are being swallowed. The `message` that's currently given is only marginally helpful.