### PR TITLE
Don't error on redirect if follow is zero

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ function Fetch(url, opts) {
 			clearTimeout(reqTimeout);
 
 			// handle redirect
-			if (self.isRedirect(res.statusCode)) {
+			if (self.isRedirect(res.statusCode) && options.follow > 0) {
 				if (options.counter >= options.follow) {
 					reject(new Error('maximum redirect reached at: ' + options.url));
 					return;


### PR DESCRIPTION
I interpret the semantics of `follow: 0` to be "just give me this response whether it's a redirect or not". I don't consider "no redirects" to be "too many" and thus an error.