### PR TITLE
Align with es6 modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var Headers = require('./lib/headers');
 var Request = require('./lib/request');
 
 module.exports = Fetch;
+module.exports.default = module.exports;
 
 /**
  * Fetch class


### PR DESCRIPTION
This adds a default export so it could be used
with es6 modules default export as well without
breaking api.