### PR TITLE
Export window.fetch in browser bundles

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,8 @@
+/**
+ * browser.js
+ *
+ * exports window.fetch when bundled by browserify/webpack
+ */
+
+module.exports = window.fetch;
+module.exports.default = module.exports;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.3",
   "description": "A light-weight module that brings window.fetch to node.js and io.js",
   "main": "index.js",
+  "browser": "browser.js",
   "scripts": {
     "test": "mocha test/test.js",
     "report": "istanbul cover _mocha -- -R spec test/test.js",


### PR DESCRIPTION
There's a conventional `browser` field in `package.json` which different bundlers (browserify, webpack, rollup) look into to find a browser-specific version of the module.

Since `node-fetch` is already an implementation of a browser feature, users (me included) may want to *not* incude it in their bundles.

Even though this is easily achievable through bundle configs, I thought it'd be a nice move towards universal node/browsers modules.