### PR TITLE
Method to not follow redirect

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,8 +127,15 @@ function Fetch(url, opts) {
 		req.on('response', function(res) {
 			clearTimeout(reqTimeout);
 
+			
 			// handle redirect
-			if (self.isRedirect(res.statusCode)) {
+			if (options.redirect !== 'manual' && self.isRedirect(res.statusCode)) {
+				
+				if (options.redirect === 'error'){
+					reject(new TypeError("Failed to fetch"))
+					return
+				}
+				
 				if (options.counter >= options.follow) {
 					reject(new Error('maximum redirect reached at: ' + options.url));
 					return;

--- a/lib/request.js
+++ b/lib/request.js
@@ -42,6 +42,7 @@ function Request(input, init) {
 	init = init || {};
 
 	// fetch spec options
+	this.redirect = init.redirect || input.redirect || 'follow';
 	this.method = init.method || input.method || 'GET';
 	this.headers = new Headers(init.headers || input.headers || {});
 	this.url = url;


### PR DESCRIPTION

Way you would do it in browser

```
let req = new Request('http://localhost:3001', {redirect: 'manual'})
window.fetch(req).then(res => console.log(res))

let req = new Request('http://localhost:3001', {redirect: 'error'})
window.fetch(req).catch(err => console.log(err instanceof TypeError))
```

```
var express = require('express')
var app = express();

app.get('/', function(req, res){
	res.set('Location', 'http://localhost:3001/hoho');
	res.status(301).send('moved temporarily')
});

app.get('/hoho', function(req, res){
	res.send('hej')
});

app.listen(3001);
```