### PR TITLE
request.js: remove unneeded input.agent

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -56,7 +56,7 @@ function Request(input, init) {
 		init.compress : input.compress !== undefined ?
 		input.compress : true;
 	this.counter = init.counter || input.counter || input.follow || 0;
-	this.agent = init.agent || input.agent || input.agent;
+	this.agent = init.agent || input.agent;
 
 	Body.call(this, init.body || this._clone(input), {
 		timeout: init.timeout || input.timeout || 0,


### PR DESCRIPTION
Check `init.agent` and `input.agent` just once and default to `undefined`.