### PR TITLE
Handle error form-data cannot calculate content-length

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,9 @@ function Fetch(url, opts) {
 				headers.set('content-length', Buffer.byteLength(options.body));
 			// detect form data input from form-data module, this hack avoid the need to add content-length header manually
 			} else if (options.body && typeof options.body.getLengthSync === 'function') {
-				headers.set('content-length', options.body.getLengthSync().toString());
+				try {
+					headers.set('content-length', options.body.getLengthSync().toString());
+				} catch (e) {}
 			// this is only necessary for older nodejs releases (before iojs merge)
 			} else if (options.body === undefined || options.body === null) {
 				headers.set('content-length', '0');


### PR DESCRIPTION
This happens when trying to send a stream of an unknown length

Fixes https://github.com/bitinn/node-fetch/issues/102