### PR TITLE
Adds polyfill support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,23 @@ Hence `node-fetch`, minimal code for a `window.fetch` compatible API on Node.js 
 
 `npm install node-fetch --save`
 
+# Polyfill
+
+External packages that depend on `fetch` will generally expect `fetch` to be available on the global object, which means that it need to be used as a polyfill to work with these. To do so, simply add `require('node-fetch/polyfill')` at the top of your application entry point.
+
+If your use Webpack to package your Node code, you can simply add `node-fetch/polyfill` in the `entry` configuration option before your application entry point e.g.:
+
+```javascript
+module.exports = {
+   entry: ['node-fetch/polyfill', './app/js']
+};
+```
+
 
 # Usage
 
 ```javascript
+// if not using the polyfill
 var fetch = require('node-fetch');
 
 // If you are not on node v0.12, set a Promise library first, eg.

--- a/polyfill.js
+++ b/polyfill.js
@@ -1,1 +1,26 @@
-global.fetch = require('./index.js');
+// commonjs
+module.exports = polyfill;
+// es6 default export compatibility
+module.exports.default = module.exports;
+
+// this is exported as a function so it can be ran multiple times for testing
+// while going around Nodejs module caching
+function polyfill() {
+
+	if (global.fetch !== undefined ||
+		global.Request !== undefined ||
+		global.Headers !== undefined ||
+		global.Response !== undefined) {
+
+		throw new Error('a fetch (or Request, Headers, Response) object is already defined globally');
+	}
+
+	var Fetch = require('./index.js');
+	global.fetch = Fetch;
+	global.Request = Fetch.Request;
+	global.Headers = Fetch.Headers;
+	global.Response = Fetch.Response;
+}
+
+// polyfill automatically
+polyfill();

--- a/polyfill.js
+++ b/polyfill.js
@@ -1,0 +1,1 @@
+global.fetch = require('./index.js');

--- a/test/test.js
+++ b/test/test.js
@@ -27,7 +27,7 @@ fetch.Promise = fetch.Promise || bluebird;
 var url, opts, local, base, polyfill;
 
 // dry-run polyfill to go around Nodejs module caching
-isolateTest(() => {
+isolateTest(function () {
 	polyfill = require('../polyfill.js')
 })
 
@@ -1286,14 +1286,14 @@ describe('node-fetch', function() {
 	});
 
 	it('should provide a polyfill', function() {
-		isolateTest(() => {
+		isolateTest(function() {
 			polyfill();
 			expect(global.fetch).to.be.an.instanceof(Function);
 		})
 	})
 
 	it('should expose other fetch globals', function() {
-		isolateTest(() => {
+		isolateTest(function() {
 			polyfill();
 			expect(global.Request).to.be.an.instanceof(Function);
 			expect(global.Headers).to.be.an.instanceof(Function);
@@ -1302,7 +1302,7 @@ describe('node-fetch', function() {
 	})
 
 	it('should throw an error if globals are polluted', function() {
-		isolateTest(() => {
+		isolateTest(function() {
 			global.fetch = 1;
 			expect(function() {
 				polyfill();

--- a/test/test.js
+++ b/test/test.js
@@ -1263,4 +1263,18 @@ describe('node-fetch', function() {
 		});
 	});
 
+	it('should provide a polyfill', function() {
+
+		// stash setup
+		var fetchPointer = fetch;
+		fetch = undefined;
+
+		require('../polyfill.js');
+		expect(global.fetch).to.be.an.instanceof(Function);
+
+		// restore setup
+		delete global.fetch;
+		fetch = fetchPointer;
+	})
+
 });


### PR DESCRIPTION
This PR adds Polyfill support for `node-fetch`, this is required to use 3rd party packages which depend on fetch.
See the `README` changes for more info.