### PR TITLE
Switch to inflateRaw when inflate header check fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var https = require('https');
 var zlib = require('zlib');
 var stream = require('stream');
 
+var Inflate = require('./lib/inflate');
 var Body = require('./lib/body');
 var Response = require('./lib/response');
 var Headers = require('./lib/headers');
@@ -174,7 +175,7 @@ function Fetch(url, opts) {
 					if (name == 'gzip' || name == 'x-gzip') {
 						body = body.pipe(zlib.createGunzip());
 					} else if (name == 'deflate' || name == 'x-deflate') {
-						body = body.pipe(zlib.createInflate());
+						body = body.pipe(new Inflate());
 					}
 				}
 			}

--- a/lib/inflate.js
+++ b/lib/inflate.js
@@ -1,0 +1,136 @@
+
+/**
+ * inflate.js
+ */
+
+var zlib = require('zlib');
+var stream = require('stream');
+
+module.exports = Inflate;
+
+/**
+ * Create Inflate instance
+ *
+ * @param   Object      options      Options for creating Inflate object
+ * @return  Inflate
+ */
+function Inflate(options) {
+
+	stream.Transform.call(this);
+
+	var self = this;
+
+	self.options = options;
+	self.inflate = zlib.createInflate(options);
+
+	self.buffer = [];
+	self.willSwitch = true;
+	self.isFinished = false;
+
+	self.inflate.on('data', onInflateData);
+	self.inflate.once('error', onInflateError);
+	self.inflate.once('end', onInflateEnd);
+	self.once('finish', onTransformFinish);
+
+	/**
+	 * Inflate data callback
+	 *
+	 * @param   Buffer   data   Decoded data from inflate 
+	 */
+	function onInflateData(data) {
+		self.willSwitch = false;
+		self.buffer = null;
+		self.push(data);
+	}
+
+	/**
+	 * Inflate error callback
+	 *
+	 * @param   Error   error 
+	 */
+	function onInflateError(error) {
+
+		// pass through errors if we're not going to switch to inflateRaw
+		if (!self.willSwitch) {
+			self.emit('error', error);
+			return;
+		}
+
+		// replace inflate with inflateRaw
+		self.inflate.removeListener('data', onInflateData);
+		self.inflate.removeListener('end', onInflateEnd);
+
+		self.inflate = zlib.createInflateRaw(options);
+
+		self.inflate.on('data', onInflateData);
+		self.inflate.on('error', onInflateError);
+		self.inflate.on('end', onInflateEnd);
+
+		// write buffer data
+		self.buffer.forEach(function(data) {
+			self.inflate.write(data.chunk, data.encoding);
+		});
+
+		if (self.isFinished) {
+			self.inflate.end();
+		}
+
+		this.willSwitch = false;
+		this.buffer = null;
+
+		self.emit('switchRaw');
+	}
+
+	/**
+	 * Inflate end callback 
+	 */
+	function onInflateEnd() {
+		self.push(null);
+	}
+
+	/**
+	 * Transform finish callback
+	 */
+	function onTransformFinish() {
+		self.willSwitch = false;
+		self.inflate.end();
+	}
+
+}
+
+require('util').inherits(Inflate, stream.Transform);
+
+/**
+ * Transform's _transform callback
+ *
+ * @param   Buffer    chunk     The chunk to be transformed
+ * @param   string    encoding  Encoding type of chunk
+ * @param   Function  callback  Callback when finish processing chunk
+ */
+Inflate.prototype._transform = function(chunk, encoding, callback) {
+	var self = this;
+	if (self.willSwitch) {
+		self.buffer.push({ chunk: chunk, encoding: encoding });
+		self.once('switchRaw', callback);
+	}
+	self.inflate.write(chunk, encoding, function() {
+		self.removeListener('switchRaw', callback);
+		callback();
+	});
+};
+
+/**
+ * Transform's _flush callback
+ *
+ * @param   Function   callback  Callback when finish flushing
+ */
+Inflate.prototype._flush = function(callback) {
+	var self = this;
+	if (self.willSwitch) {
+		self.once('switchRaw', callback);
+	}
+	self.inflate.end(function() {
+		self.removeListener('switchRaw', callback);
+		callback();
+	});
+};

--- a/lib/inflate.js
+++ b/lib/inflate.js
@@ -15,87 +15,9 @@ module.exports = Inflate;
  * @return  Inflate
  */
 function Inflate(options) {
-
 	stream.Transform.call(this);
-
-	var self = this;
-
-	self.options = options;
-	self.inflate = zlib.createInflate(options);
-
-	self.buffer = [];
-	self.willSwitch = true;
-	self.isFinished = false;
-
-	self.inflate.on('data', onInflateData);
-	self.inflate.once('error', onInflateError);
-	self.inflate.once('end', onInflateEnd);
-	self.once('finish', onTransformFinish);
-
-	/**
-	 * Inflate data callback
-	 *
-	 * @param   Buffer   data   Decoded data from inflate 
-	 */
-	function onInflateData(data) {
-		self.willSwitch = false;
-		self.buffer = null;
-		self.push(data);
-	}
-
-	/**
-	 * Inflate error callback
-	 *
-	 * @param   Error   error 
-	 */
-	function onInflateError(error) {
-
-		// pass through errors if we're not going to switch to inflateRaw
-		if (!self.willSwitch) {
-			self.emit('error', error);
-			return;
-		}
-
-		// replace inflate with inflateRaw
-		self.inflate.removeListener('data', onInflateData);
-		self.inflate.removeListener('end', onInflateEnd);
-
-		self.inflate = zlib.createInflateRaw(options);
-
-		self.inflate.on('data', onInflateData);
-		self.inflate.on('error', onInflateError);
-		self.inflate.on('end', onInflateEnd);
-
-		// write buffer data
-		self.buffer.forEach(function(data) {
-			self.inflate.write(data.chunk, data.encoding);
-		});
-
-		if (self.isFinished) {
-			self.inflate.end();
-		}
-
-		this.willSwitch = false;
-		this.buffer = null;
-
-		self.emit('switchRaw');
-	}
-
-	/**
-	 * Inflate end callback 
-	 */
-	function onInflateEnd() {
-		self.push(null);
-	}
-
-	/**
-	 * Transform finish callback
-	 */
-	function onTransformFinish() {
-		self.willSwitch = false;
-		self.inflate.end();
-	}
-
+	this.options = options;
+	this.inflate = null;
 }
 
 require('util').inherits(Inflate, stream.Transform);
@@ -109,14 +31,33 @@ require('util').inherits(Inflate, stream.Transform);
  */
 Inflate.prototype._transform = function(chunk, encoding, callback) {
 	var self = this;
-	if (self.willSwitch) {
-		self.buffer.push({ chunk: chunk, encoding: encoding });
-		self.once('switchRaw', callback);
+
+	if (!self.inflate) {
+
+		// check if the stream has a header, see http://stackoverflow.com/a/37528114
+		if ((new Buffer(chunk, encoding)[0] & 0x0F) === 0x08) {
+			self.inflate = zlib.createInflate(self.options);
+		} else {
+			self.inflate = zlib.createInflateRaw(self.options);
+		}
+
+		self.once('finish', function() {
+			self.inflate.end();
+		});
+		self.inflate.on('data', function(chunk) {
+			self.push(chunk);
+		});
+		self.inflate.on('error', function(error) {
+			self.emit('error', error);
+		});
+		self.inflate.once('end', function() {
+			self.isInflateEnded = true;
+			self.push(null);
+		});
+
 	}
-	self.inflate.write(chunk, encoding, function() {
-		self.removeListener('switchRaw', callback);
-		callback();
-	});
+
+	self.inflate.write(chunk, encoding, callback);
 };
 
 /**
@@ -125,12 +66,9 @@ Inflate.prototype._transform = function(chunk, encoding, callback) {
  * @param   Function   callback  Callback when finish flushing
  */
 Inflate.prototype._flush = function(callback) {
-	var self = this;
-	if (self.willSwitch) {
-		self.once('switchRaw', callback);
-	}
-	self.inflate.end(function() {
-		self.removeListener('switchRaw', callback);
+	if (this.inflate && !this.isInflateEnded) {
+		this.inflate.once('end', callback);
+	} else {
 		callback();
-	});
+	}
 };

--- a/test/server.js
+++ b/test/server.js
@@ -82,6 +82,15 @@ TestServer.prototype.router = function(req, res) {
 		});
 	}
 
+	if (p === '/deflate-raw') {
+		res.statusCode = 200;
+		res.setHeader('Content-Type', 'text/plain');
+		res.setHeader('Content-Encoding', 'deflate');
+		zlib.deflateRaw('hello world', function(err, buffer) {
+			res.end(buffer);
+		});
+	}
+
 	if (p === '/sdch') {
 		res.statusCode = 200;
 		res.setHeader('Content-Type', 'text/plain');

--- a/test/test.js
+++ b/test/test.js
@@ -493,6 +493,17 @@ describe('node-fetch', function() {
 		});
 	});
 
+	it('should decompress raw deflate response', function() {
+		url = base + '/deflate-raw';
+		return fetch(url).then(function(res) {
+			expect(res.headers.get('content-type')).to.equal('text/plain');
+			return res.text().then(function(result) {
+				expect(result).to.be.a('string');
+				expect(result).to.equal('hello world');
+			});
+		});
+	});
+
 	it('should skip decompression if unsupported', function() {
 		url = base + '/sdch';
 		return fetch(url).then(function(res) {


### PR DESCRIPTION
See [chromium/filter/gzip_filter.cc:131](https://chromium.googlesource.com/chromium/src/net/+/master/filter/gzip_filter.cc#131)

> As noted in Mozilla implementation, some servers such as Apache with mod_deflate don't generate zlib headers.
> See 677409 for instances where this work around is needed.
> Insert a dummy zlib header and try again.

Possible fix for #93 and #45 