### PR TITLE
default to 200 response status

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -23,7 +23,7 @@ function Response(body, opts) {
 	opts = opts || {};
 
 	this.url = opts.url;
-	this.status = opts.status;
+	this.status = opts.status || 200;
 	this.statusText = opts.statusText || http.STATUS_CODES[this.status];
 	this.headers = new Headers(opts.headers);
 	this.ok = this.status >= 200 && this.status < 300;


### PR DESCRIPTION
As documented in the fetch spec https://fetch.spec.whatwg.org/#dom-response, the status should default to 200

```
dictionary ResponseInit {
  unsigned short status = 200;
  ByteString statusText = "OK";
  HeadersInit headers;
};
```

While the aim of node-fetch isn't to 100% match the spec, this seems like a reasonable bit of compliance to add.

Note - this PR implicitly sets status text to 'OK' too