### PR TITLE
add expectations for numeric status codes

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -23,6 +23,11 @@ function Response(body, opts) {
 	opts = opts || {};
 
 	this.url = opts.url;
+
+	if (opts.status && (typeof opts.status !== 'number' || parseInt(opts.status, 10) !== opts.status || opts.status < 200 || opts.status > 599)) {
+		throw new RangeError('Failed to construct \'Response\': The status provided is outside the range [200, 599]');
+	}
+
 	this.status = opts.status || 200;
 	this.statusText = opts.statusText || http.STATUS_CODES[this.status];
 	this.headers = new Headers(opts.headers);

--- a/test/test.js
+++ b/test/test.js
@@ -1274,6 +1274,32 @@ describe('node-fetch', function() {
 		});
 	});
 
+	it('should default to 200 in Response constructor', function() {
+		var res = new Response('a=1');
+		expect(res.status).to.equal(200);
+	});
+
+	it('should expect status between 200 and 599 in Response constructor', function() {
+		try {
+			new Response('a=1', {status: 199});
+		} catch (e) {
+			expect(e).to.be.an.instanceof(RangeError);
+			expect(e.message).to.equal('Failed to construct \'Response\': The status provided is outside the range [200, 599]');
+		}
+		try {
+			new Response('a=1', {status: 600});
+		} catch (e) {
+			expect(e).to.be.an.instanceof(RangeError);
+			expect(e.message).to.equal('Failed to construct \'Response\': The status provided is outside the range [200, 599]');
+		}
+		try {
+			new Response('a=1', {status: '200'});
+		} catch (e) {
+			expect(e).to.be.an.instanceof(RangeError);
+			expect(e.message).to.equal('Failed to construct \'Response\': The status provided is outside the range [200, 599]');
+		}
+	});
+
 	it('should support parsing headers in Request constructor', function() {
 		url = base;
 		var req = new Request(url, {


### PR DESCRIPTION
This implements another bit of conformance with the `Response` spec. https://fetch.spec.whatwg.org/#dom-response. 