### PR TITLE
Update README.md form.getHeaders note

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ fetch('http://httpbin.org/post', { method: 'POST', body: form })
 	});
 
 // post with form-data (custom headers)
-
+// IMPORTANT: form.getHeaders does not work in browser
 var FormData = require('form-data');
 var form = new FormData();
 form.append('a', 1);


### PR DESCRIPTION
getHeaders exists only in node environment. (if you run it server side). Browser FormData does not support this API. 