### PR TITLE
Change output header key to be same as input string

### DIFF
--- a/lib/headers.js
+++ b/lib/headers.js
@@ -5,6 +5,8 @@
  * Headers class offers convenient helpers
  */
 
+var caseless = require('caseless');
+
 module.exports = Headers;
 
 /**
@@ -15,8 +17,8 @@ module.exports = Headers;
  */
 function Headers(headers) {
 
-	var self = this;
 	this._headers = {};
+	this._dict = caseless(this._headers);
 
 	// Headers
 	if (headers instanceof Headers) {
@@ -37,8 +39,8 @@ function Headers(headers) {
 
 		} else if (headers[prop] instanceof Array) {
 			headers[prop].forEach(function(item) {
-				self.append(prop, item.toString());
-			});
+				this.append(prop, item.toString());
+			}, this);
 		}
 	}
 
@@ -51,7 +53,7 @@ function Headers(headers) {
  * @return  Mixed
  */
 Headers.prototype.get = function(name) {
-	var list = this._headers[name.toLowerCase()];
+	var list = this._dict.get(name);
 	return list ? list[0] : null;
 };
 
@@ -66,7 +68,7 @@ Headers.prototype.getAll = function(name) {
 		return [];
 	}
 
-	return this._headers[name.toLowerCase()];
+	return this._dict.get(name);
 };
 
 /**
@@ -92,7 +94,7 @@ Headers.prototype.forEach = function(callback, thisArg) {
  * @return  Void
  */
 Headers.prototype.set = function(name, value) {
-	this._headers[name.toLowerCase()] = [value];
+	this._dict.set(name, [value]);
 };
 
 /**
@@ -108,7 +110,7 @@ Headers.prototype.append = function(name, value) {
 		return;
 	}
 
-	this._headers[name.toLowerCase()].push(value);
+	this._dict.get(name).push(value);
 };
 
 /**
@@ -118,7 +120,7 @@ Headers.prototype.append = function(name, value) {
  * @return  Boolean
  */
 Headers.prototype.has = function(name) {
-	return this._headers.hasOwnProperty(name.toLowerCase());
+	return this._dict.has(name);
 };
 
 /**
@@ -128,7 +130,7 @@ Headers.prototype.has = function(name) {
  * @return  Void
  */
 Headers.prototype['delete'] = function(name) {
-	delete this._headers[name.toLowerCase()];
+	this._dict.del(name);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "resumer": "0.0.0"
   },
   "dependencies": {
+    "caseless": "^0.11.0",
     "encoding": "^0.1.11",
     "is-stream": "^1.0.1"
   }

--- a/test/test.js
+++ b/test/test.js
@@ -697,7 +697,7 @@ describe('node-fetch', function() {
 		form.append('a','1');
 
 		var headers = form.getHeaders();
-		headers['b'] = '2';
+		headers['B'] = '2';
 
 		url = base + '/multipart';
 		opts = {


### PR DESCRIPTION
In now implementation, all output header key convert to lowercase, when request server.
I'd prefer to output the original string for request header.

And I'm sure that the header key is case insensitive.