### PR TITLE
[WIP] piping gunzip to a passthrough requires a call to resume?

### DIFF
--- a/lib/body.js
+++ b/lib/body.js
@@ -8,6 +8,7 @@
 var convert = require('encoding').convert;
 var bodyStream = require('is-stream');
 var PassThrough = require('stream').PassThrough;
+var Gunzip = require('zlib').Gunzip;
 var FetchError = require('./fetch-error');
 
 module.exports = Body;
@@ -241,6 +242,12 @@ Body.prototype._clone = function(instance) {
 		// tee instance body
 		p1 = new PassThrough();
 		p2 = new PassThrough();
+
+		if (body instanceof Gunzip) {
+			p1.resume();
+			p2.resume();
+		}
+
 		body.pipe(p1);
 		body.pipe(p2);
 		// set instance body to teed body and return the other teed body

--- a/test/server.js
+++ b/test/server.js
@@ -186,6 +186,17 @@ TestServer.prototype.router = function(req, res) {
 		res.end(convert('中文', 'gbk'));
 	}
 
+	if (p === '/encoding/chunked/gzip') {
+		res.statusCode = 200;
+		res.setHeader('Content-Type', 'text/html');
+		res.setHeader('Content-Encoding', 'gzip');
+		res.setHeader('Transfer-Encoding', 'chunked');
+		zlib.gzip(new Array(40000).join('a'), function(err, buffer) {
+			res.write(buffer);
+			res.end();
+		});
+	}
+
 	if (p === '/encoding/chunked') {
 		res.statusCode = 200;
 		res.setHeader('Content-Type', 'text/html');

--- a/test/test.js
+++ b/test/test.js
@@ -1015,6 +1015,15 @@ describe('node-fetch', function() {
 		});
 	});
 
+	it('should allow cloning a response, when stream is Gunzip', function (done) {
+		url = base + '/encoding/chunked/gzip';
+		fetch(url).then(function(res) {
+			res.clone().text().then(function (text) {
+				done();
+			});
+		});
+	});
+
 	it('should allow cloning a json response and log it as text response', function() {
 		url = base + '/json';
 		return fetch(url).then(function(res) {


### PR DESCRIPTION
This is very much a work in progress. I'm only half way sure of what's going on here and would love to hear others thoughts.

The issue is this:

Calling `clone` on a response with gzip encoding and multiple data chunks seems to miss some of `data` events and the `end` event which deems the response useless to read.

Trying to read from the original body immediately after the clone seems to solve the issue but I'm confused why as it's just another instance of PassThrough.

From what I can tell, this seems to be an issue only when the stream is Gunzip.

PS: maybe this is related? https://nodejs.org/api/stream.html#stream_additional_notes

