### PR TITLE
Testing both form-data 1.x and 2.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,10 @@ node_js:
   - "0.10"
   - "0.12"
   - "node"
+env:
+  - FORMDATA_VERSION=1.0.0
+  - FORMDATA_VERSION=2.1.0
+before_script:
+  - 'if [ "$FORMDATA_VERSION" ]; then npm install form-data@^$FORMDATA_VERSION; fi'
 before_install: npm install -g npm
 script: npm run coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Changelog
 
 # 1.x release
 
+## v1.6.3
+
+- Fix: support `form-data` 2.x releases (requires `form-data` >= 2.1.0)
+
 ## v1.6.2
 
 - Enhance: minor document update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 
 ## v1.6.3
 
+- Enhance: error handling document to explain `FetchError` design
 - Fix: support `form-data` 2.x releases (requires `form-data` >= 2.1.0)
 
 ## v1.6.2

--- a/ERROR-HANDLING.md
+++ b/ERROR-HANDLING.md
@@ -1,0 +1,21 @@
+
+Error handling with node-fetch
+==============================
+
+Because `window.fetch` isn't designed to transparent about the cause of request errors, we have to come up with our own solutions.
+
+The basics:
+
+- All [operational errors](https://www.joyent.com/node-js/production/design/errors) are rejected as [FetchError](https://github.com/bitinn/node-fetch/blob/master/lib/fetch-error.js), you can handle them all through promise `catch` clause.
+
+- All errors comes with `err.message` detailing the cause of errors.
+
+- All errors originated from `node-fetch` are marked with custom `err.type`.
+
+- All errors originated from Node.js core are marked with `err.type = system`, and contains addition `err.code` and `err.errno` for error handling, they are alias to error codes thrown by Node.js core.
+
+- [Programmer errors](https://www.joyent.com/node-js/production/design/errors) are either thrown as soon as possible, or rejected with default `Error` with `err.message` for ease of troubleshooting.
+
+List of error types:
+
+- Because we maintain 100% coverage, see [test.js](https://github.com/bitinn/node-fetch/blob/master/test/test.js) for a full list of custom `FetchError` types, as well as some of the common errors from Node.js

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See Matt Andrews' [isomorphic-fetch](https://github.com/matthew-andrews/isomorph
 - Use native promise, but allow substituting it with [insert your favorite promise library].
 - Use native stream for body, on both request and response.
 - Decode content encoding (gzip/deflate) properly, and convert string output (such as `res.text()` and `res.json()`) to UTF-8 automatically.
-- Useful extensions such as timeout, redirect limit, response size limit, explicit errors for troubleshooting.
+- Useful extensions such as timeout, redirect limit, response size limit, [explicit errors](https://github.com/bitinn/node-fetch/blob/master/ERROR-HANDLING.md) for troubleshooting.
 
 
 # Difference from client-side fetch

--- a/index.js
+++ b/index.js
@@ -94,8 +94,14 @@ function Fetch(url, opts) {
 			if (typeof options.body === 'string') {
 				headers.set('content-length', Buffer.byteLength(options.body));
 			// detect form data input from form-data module, this hack avoid the need to add content-length header manually
-			} else if (options.body && typeof options.body.getLengthSync === 'function' && options.body._lengthRetrievers.length == 0) {
-				headers.set('content-length', options.body.getLengthSync().toString());
+			} else if (options.body && typeof options.body.getLengthSync === 'function') {
+				// for form-data 1.x
+				if (options.body._lengthRetrievers && options.body._lengthRetrievers.length == 0) {
+					headers.set('content-length', options.body.getLengthSync().toString());
+				// for form-data 2.x
+				} else if (options.body.hasKnownLength && options.body.hasKnownLength()) {
+					headers.set('content-length', options.body.getLengthSync().toString());
+				}
 			// this is only necessary for older nodejs releases (before iojs merge)
 			} else if (options.body === undefined || options.body === null) {
 				headers.set('content-length', '0');

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
     "coveralls": "^2.11.2",
-    "form-data": "^1.0.0-rc1",
+    "form-data": "^1.0.0",
     "istanbul": "^0.4.2",
     "mocha": "^2.1.0",
     "parted": "^0.1.1",


### PR DESCRIPTION
Unfortunately this lowers our coverage a bit because npm doesn't allow me to install 2 different versions of `form-data` (I have to test it using environment variables).

If we drop `form-data` 1.x support it will be a breaking change (thus bumping `node-fetch` to 2.x) but I want to keep it as 1.x until we can safely drop both Node 0.10 and 0.12 support (still accounts for 20% of production environment per [April 2016 survey](https://nodejs.org/static/documents/2016-survey-report.pdf)).

TL;DR: support both `form-data` 1.x and 2.x for now in `node-fetch` 1.x, and by the end of this year, we will bump to `node-fetch` 2.x and drop `form-data` 1.x support in there.