### PR TITLE
Add 'post javascript object' example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,19 @@ fetch('http://httpbin.org/post', { method: 'POST', body: stream })
 		console.log(json);
 	});
 
+// post with JavaScript object
+
+var body = { a: 1 };
+fetch('http://httpbin.org/post', { 
+        method: 'POST',
+        body:    JSON.stringify(body),
+        headers: { 'Content-Type': 'application/json' },
+    }).then(function(res) {
+        return res.json();
+    }).then(function(json) {
+        console.log(json);
+    });
+
 // post with form-data (detect multipart)
 
 var FormData = require('form-data');

--- a/README.md
+++ b/README.md
@@ -129,14 +129,14 @@ fetch('http://httpbin.org/post', { method: 'POST', body: stream })
 
 var body = { a: 1 };
 fetch('http://httpbin.org/post', { 
-        method: 'POST',
-        body:    JSON.stringify(body),
-        headers: { 'Content-Type': 'application/json' },
-    }).then(function(res) {
-        return res.json();
-    }).then(function(json) {
-        console.log(json);
-    });
+		method: 'POST',
+		body:    JSON.stringify(body),
+		headers: { 'Content-Type': 'application/json' },
+	}).then(function(res) {
+		return res.json();
+	}).then(function(json) {
+		console.log(json);
+	});
 
 // post with form-data (detect multipart)
 

--- a/README.md
+++ b/README.md
@@ -125,14 +125,15 @@ fetch('http://httpbin.org/post', { method: 'POST', body: stream })
 		console.log(json);
 	});
 
-// post with JavaScript object
+// post with JSON
 
 var body = { a: 1 };
 fetch('http://httpbin.org/post', { 
-		method: 'POST',
-		body:    JSON.stringify(body),
-		headers: { 'Content-Type': 'application/json' },
-	}).then(function(res) {
+	method: 'POST',
+	body:    JSON.stringify(body),
+	headers: { 'Content-Type': 'application/json' },
+})
+	.then(function(res) {
 		return res.json();
 	}).then(function(json) {
 		console.log(json);


### PR DESCRIPTION
Wasn't sure initially if `JSON.stringify()` for post body would work, then it took me longer than it should have to work out that `Content-Type` was needed for POST JSON to work with koa-body (and perhaps other body parsers?), so this might help others.