### PR TITLE
Convert Headers to ES2015 and implement Iterable interface

### DIFF
--- a/src/headers.js
+++ b/src/headers.js
@@ -179,6 +179,13 @@ export default class Headers {
 	[Symbol.iterator]() {
 		return this.entries();
 	}
+
+	/**
+	 * Tag used by `Object.prototype.toString()`.
+	 */
+	get [Symbol.toStringTag]() {
+		return 'Headers';
+	}
 }
 
 const ITEMS = Symbol('items');

--- a/src/headers.js
+++ b/src/headers.js
@@ -5,137 +5,132 @@
  * Headers class offers convenient helpers
  */
 
-module.exports = Headers;
+export default class Headers {
+	/**
+	 * Headers class
+	 *
+	 * @param   Object  headers  Response headers
+	 * @return  Void
+	 */
+	constructor(headers) {
+		this._headers = {};
 
-/**
- * Headers class
- *
- * @param   Object  headers  Response headers
- * @return  Void
- */
-function Headers(headers) {
-
-	var self = this;
-	this._headers = {};
-
-	// Headers
-	if (headers instanceof Headers) {
-		headers = headers.raw();
-	}
-
-	// plain object
-	for (var prop in headers) {
-		if (!headers.hasOwnProperty(prop)) {
-			continue;
+		// Headers
+		if (headers instanceof Headers) {
+			headers = headers.raw();
 		}
 
-		if (typeof headers[prop] === 'string') {
-			this.set(prop, headers[prop]);
+		// plain object
+		for (const prop in headers) {
+			if (!headers.hasOwnProperty(prop)) {
+				continue;
+			}
 
-		} else if (typeof headers[prop] === 'number' && !isNaN(headers[prop])) {
-			this.set(prop, headers[prop].toString());
+			if (typeof headers[prop] === 'string') {
+				this.set(prop, headers[prop]);
+			} else if (typeof headers[prop] === 'number' && !isNaN(headers[prop])) {
+				this.set(prop, headers[prop].toString());
+			} else if (headers[prop] instanceof Array) {
+				headers[prop].forEach(item => {
+					this.append(prop, item.toString());
+				});
+			}
+		}
+	}
 
-		} else if (headers[prop] instanceof Array) {
-			headers[prop].forEach(function(item) {
-				self.append(prop, item.toString());
+	/**
+	 * Return first header value given name
+	 *
+	 * @param   String  name  Header name
+	 * @return  Mixed
+	 */
+	get(name) {
+		const list = this._headers[name.toLowerCase()];
+		return list ? list[0] : null;
+	}
+
+	/**
+	 * Return all header values given name
+	 *
+	 * @param   String  name  Header name
+	 * @return  Array
+	 */
+	getAll(name) {
+		if (!this.has(name)) {
+			return [];
+		}
+
+		return this._headers[name.toLowerCase()];
+	}
+
+	/**
+	 * Iterate over all headers
+	 *
+	 * @param   Function  callback  Executed for each item with parameters (value, name, thisArg)
+	 * @param   Boolean   thisArg   `this` context for callback function
+	 * @return  Void
+	 */
+	forEach(callback, thisArg) {
+		Object.getOwnPropertyNames(this._headers).forEach(name => {
+			this._headers[name].forEach(value => {
+				callback.call(thisArg, value, name, this);
 			});
+		});
+	}
+
+	/**
+	 * Overwrite header values given name
+	 *
+	 * @param   String  name   Header name
+	 * @param   String  value  Header value
+	 * @return  Void
+	 */
+	set(name, value) {
+		this._headers[name.toLowerCase()] = [value];
+	}
+
+	/**
+	 * Append a value onto existing header
+	 *
+	 * @param   String  name   Header name
+	 * @param   String  value  Header value
+	 * @return  Void
+	 */
+	append(name, value) {
+		if (!this.has(name)) {
+			this.set(name, value);
+			return;
 		}
+
+		this._headers[name.toLowerCase()].push(value);
 	}
 
+	/**
+	 * Check for header name existence
+	 *
+	 * @param   String   name  Header name
+	 * @return  Boolean
+	 */
+	has(name) {
+		return this._headers.hasOwnProperty(name.toLowerCase());
+	}
+
+	/**
+	 * Delete all header values given name
+	 *
+	 * @param   String  name  Header name
+	 * @return  Void
+	 */
+	delete(name) {
+		delete this._headers[name.toLowerCase()];
+	};
+
+	/**
+	 * Return raw headers (non-spec api)
+	 *
+	 * @return  Object
+	 */
+	raw() {
+		return this._headers;
+	}
 }
-
-/**
- * Return first header value given name
- *
- * @param   String  name  Header name
- * @return  Mixed
- */
-Headers.prototype.get = function(name) {
-	var list = this._headers[name.toLowerCase()];
-	return list ? list[0] : null;
-};
-
-/**
- * Return all header values given name
- *
- * @param   String  name  Header name
- * @return  Array
- */
-Headers.prototype.getAll = function(name) {
-	if (!this.has(name)) {
-		return [];
-	}
-
-	return this._headers[name.toLowerCase()];
-};
-
-/**
- * Iterate over all headers
- *
- * @param   Function  callback  Executed for each item with parameters (value, name, thisArg)
- * @param   Boolean   thisArg   `this` context for callback function
- * @return  Void
- */
-Headers.prototype.forEach = function(callback, thisArg) {
-	Object.getOwnPropertyNames(this._headers).forEach(function(name) {
-		this._headers[name].forEach(function(value) {
-			callback.call(thisArg, value, name, this)
-		}, this)
-	}, this)
-}
-
-/**
- * Overwrite header values given name
- *
- * @param   String  name   Header name
- * @param   String  value  Header value
- * @return  Void
- */
-Headers.prototype.set = function(name, value) {
-	this._headers[name.toLowerCase()] = [value];
-};
-
-/**
- * Append a value onto existing header
- *
- * @param   String  name   Header name
- * @param   String  value  Header value
- * @return  Void
- */
-Headers.prototype.append = function(name, value) {
-	if (!this.has(name)) {
-		this.set(name, value);
-		return;
-	}
-
-	this._headers[name.toLowerCase()].push(value);
-};
-
-/**
- * Check for header name existence
- *
- * @param   String   name  Header name
- * @return  Boolean
- */
-Headers.prototype.has = function(name) {
-	return this._headers.hasOwnProperty(name.toLowerCase());
-};
-
-/**
- * Delete all header values given name
- *
- * @param   String  name  Header name
- * @return  Void
- */
-Headers.prototype['delete'] = function(name) {
-	delete this._headers[name.toLowerCase()];
-};
-
-/**
- * Return raw headers (non-spec api)
- *
- * @return  Object
- */
-Headers.prototype.raw = function() {
-	return this._headers;
-};

--- a/src/headers.js
+++ b/src/headers.js
@@ -135,4 +135,74 @@ export default class Headers {
 	raw() {
 		return this[MAP];
 	}
+
+	/**
+	 * Get an iterator on keys.
+	 *
+	 * @return  Iterator
+	 */
+	keys() {
+		const keys = [];
+		this.forEach((_, name) => keys.push(name));
+		return new Iterator(keys);
+	}
+
+	/**
+	 * Get an iterator on values.
+	 *
+	 * @return  Iterator
+	 */
+	values() {
+		const values = [];
+		this.forEach(value => values.push(value));
+		return new Iterator(values);
+	}
+
+	/**
+	 * Get an iterator on entries.
+	 *
+	 * @return  Iterator
+	 */
+	entries() {
+		const entries = [];
+		this.forEach((value, name) => entries.push([name, value]));
+		return new Iterator(entries);
+	}
+
+	/**
+	 * Get an iterator on entries.
+	 *
+	 * This is the default iterator of the Headers object.
+	 *
+	 * @return  Iterator
+	 */
+	[Symbol.iterator]() {
+		return this.entries();
+	}
+}
+
+const ITEMS = Symbol('items');
+class Iterator {
+	constructor(items) {
+		this[ITEMS] = items;
+	}
+
+	next() {
+		if (!this[ITEMS].length) {
+			return {
+				value: undefined,
+				done: true
+			};
+		}
+
+		return {
+			value: this[ITEMS].shift(),
+			done: false
+		};
+
+	}
+
+	[Symbol.iterator]() {
+		return this;
+	}
 }

--- a/src/headers.js
+++ b/src/headers.js
@@ -5,6 +5,8 @@
  * Headers class offers convenient helpers
  */
 
+export const MAP = Symbol('map');
+
 export default class Headers {
 	/**
 	 * Headers class
@@ -13,7 +15,7 @@ export default class Headers {
 	 * @return  Void
 	 */
 	constructor(headers) {
-		this._headers = {};
+		this[MAP] = {};
 
 		// Headers
 		if (headers instanceof Headers) {
@@ -45,7 +47,7 @@ export default class Headers {
 	 * @return  Mixed
 	 */
 	get(name) {
-		const list = this._headers[name.toLowerCase()];
+		const list = this[MAP][name.toLowerCase()];
 		return list ? list[0] : null;
 	}
 
@@ -60,7 +62,7 @@ export default class Headers {
 			return [];
 		}
 
-		return this._headers[name.toLowerCase()];
+		return this[MAP][name.toLowerCase()];
 	}
 
 	/**
@@ -71,8 +73,8 @@ export default class Headers {
 	 * @return  Void
 	 */
 	forEach(callback, thisArg) {
-		Object.getOwnPropertyNames(this._headers).forEach(name => {
-			this._headers[name].forEach(value => {
+		Object.getOwnPropertyNames(this[MAP]).forEach(name => {
+			this[MAP][name].forEach(value => {
 				callback.call(thisArg, value, name, this);
 			});
 		});
@@ -86,7 +88,7 @@ export default class Headers {
 	 * @return  Void
 	 */
 	set(name, value) {
-		this._headers[name.toLowerCase()] = [value];
+		this[MAP][name.toLowerCase()] = [value];
 	}
 
 	/**
@@ -102,7 +104,7 @@ export default class Headers {
 			return;
 		}
 
-		this._headers[name.toLowerCase()].push(value);
+		this[MAP][name.toLowerCase()].push(value);
 	}
 
 	/**
@@ -112,7 +114,7 @@ export default class Headers {
 	 * @return  Boolean
 	 */
 	has(name) {
-		return this._headers.hasOwnProperty(name.toLowerCase());
+		return this[MAP].hasOwnProperty(name.toLowerCase());
 	}
 
 	/**
@@ -122,7 +124,7 @@ export default class Headers {
 	 * @return  Void
 	 */
 	delete(name) {
-		delete this._headers[name.toLowerCase()];
+		delete this[MAP][name.toLowerCase()];
 	};
 
 	/**
@@ -131,6 +133,6 @@ export default class Headers {
 	 * @return  Object
 	 */
 	raw() {
-		return this._headers;
+		return this[MAP];
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ var stream = require('stream');
 
 var Body = require('./body');
 var Response = require('./response');
-var Headers = require('./headers');
+import Headers from './headers';
 var Request = require('./request');
 var FetchError = require('./fetch-error');
 

--- a/src/request.js
+++ b/src/request.js
@@ -6,7 +6,7 @@
  */
 
 var parse_url = require('url').parse;
-var Headers = require('./headers');
+import Headers from './headers';
 var Body = require('./body');
 
 module.exports = Request;

--- a/src/response.js
+++ b/src/response.js
@@ -6,7 +6,7 @@
  */
 
 var http = require('http');
-var Headers = require('./headers');
+import Headers from './headers';
 var Body = require('./body');
 
 module.exports = Response;

--- a/test/test.js
+++ b/test/test.js
@@ -1131,6 +1131,65 @@ describe('node-fetch', function() {
 		expect(result).to.deep.equal(expected);
 	});
 
+	it('should allow iterating through all headers', function() {
+		var headers = new Headers({
+			a: 1
+			, b: [2, 3]
+			, c: [4]
+		});
+		expect(headers).to.have.property(Symbol.iterator);
+		expect(headers).to.have.property('keys');
+		expect(headers).to.have.property('values');
+		expect(headers).to.have.property('entries');
+
+		var result, expected;
+
+		result = [];
+		for (let [key, val] of headers) {
+			result.push([key, val]);
+		}
+
+		expected = [
+			["a", "1"]
+			, ["b", "2"]
+			, ["b", "3"]
+			, ["c", "4"]
+		];
+		expect(result).to.deep.equal(expected);
+
+		result = [];
+		for (let [key, val] of headers.entries()) {
+			result.push([key, val]);
+		}
+		expect(result).to.deep.equal(expected);
+
+		result = [];
+		for (let key of headers.keys()) {
+			result.push(key);
+		}
+
+		expected = [
+			"a"
+			, "b"
+			, "b"
+			, "c"
+		];
+		expect(result).to.deep.equal(expected);
+
+		result = [];
+		for (let key of headers.values()) {
+			result.push(key);
+		}
+
+		expected = [
+			"1"
+			, "2"
+			, "3"
+			, "4"
+		];
+		expect(result).to.deep.equal(expected);
+	});
+
 	it('should allow deleting header', function() {
 		url = base + '/cookie';
 		return fetch(url).then(function(res) {

--- a/test/test.js
+++ b/test/test.js
@@ -17,7 +17,7 @@ var TestServer = require('./server');
 
 // test subjects
 var fetch = require('../src/index.js');
-var Headers = require('../src/headers.js');
+import Headers from '../src/headers.js';
 var Response = require('../src/response.js');
 var Request = require('../src/request.js');
 var Body = require('../src/body.js');

--- a/test/test.js
+++ b/test/test.js
@@ -1178,49 +1178,53 @@ describe('node-fetch', function() {
 		res.m = new Buffer('test');
 
 		var h1 = new Headers(res);
+		var h1Raw = h1.raw();
 
-		expect(h1._headers['a']).to.include('string');
-		expect(h1._headers['b']).to.include('1');
-		expect(h1._headers['b']).to.include('2');
-		expect(h1._headers['c']).to.include('');
-		expect(h1._headers['d']).to.be.undefined;
+		expect(h1Raw['a']).to.include('string');
+		expect(h1Raw['b']).to.include('1');
+		expect(h1Raw['b']).to.include('2');
+		expect(h1Raw['c']).to.include('');
+		expect(h1Raw['d']).to.be.undefined;
 
-		expect(h1._headers['e']).to.include('1');
-		expect(h1._headers['f']).to.include('1');
-		expect(h1._headers['f']).to.include('2');
+		expect(h1Raw['e']).to.include('1');
+		expect(h1Raw['f']).to.include('1');
+		expect(h1Raw['f']).to.include('2');
 
-		expect(h1._headers['g']).to.be.undefined;
-		expect(h1._headers['h']).to.be.undefined;
-		expect(h1._headers['i']).to.be.undefined;
-		expect(h1._headers['j']).to.be.undefined;
-		expect(h1._headers['k']).to.be.undefined;
-		expect(h1._headers['l']).to.be.undefined;
-		expect(h1._headers['m']).to.be.undefined;
+		expect(h1Raw['g']).to.be.undefined;
+		expect(h1Raw['h']).to.be.undefined;
+		expect(h1Raw['i']).to.be.undefined;
+		expect(h1Raw['j']).to.be.undefined;
+		expect(h1Raw['k']).to.be.undefined;
+		expect(h1Raw['l']).to.be.undefined;
+		expect(h1Raw['m']).to.be.undefined;
 
-		expect(h1._headers['z']).to.be.undefined;
+		expect(h1Raw['z']).to.be.undefined;
 	});
 
 	it('should wrap headers', function() {
 		var h1 = new Headers({
 			a: '1'
 		});
+		var h1Raw = h1.raw();
 
 		var h2 = new Headers(h1);
 		h2.set('b', '1');
+		var h2Raw = h2.raw();
 
 		var h3 = new Headers(h2);
 		h3.append('a', '2');
+		var h3Raw = h3.raw();
 
-		expect(h1._headers['a']).to.include('1');
-		expect(h1._headers['a']).to.not.include('2');
+		expect(h1Raw['a']).to.include('1');
+		expect(h1Raw['a']).to.not.include('2');
 
-		expect(h2._headers['a']).to.include('1');
-		expect(h2._headers['a']).to.not.include('2');
-		expect(h2._headers['b']).to.include('1');
+		expect(h2Raw['a']).to.include('1');
+		expect(h2Raw['a']).to.not.include('2');
+		expect(h2Raw['b']).to.include('1');
 
-		expect(h3._headers['a']).to.include('1');
-		expect(h3._headers['a']).to.include('2');
-		expect(h3._headers['b']).to.include('1');
+		expect(h3Raw['a']).to.include('1');
+		expect(h3Raw['a']).to.include('2');
+		expect(h3Raw['b']).to.include('1');
 	});
 
 	it('should support fetch with Request instance', function() {


### PR DESCRIPTION
Closes #127, #174.

The approach taken by this pull request versus #174 is that the iterator methods are greatly simplified as well as more correct w.r.t. the behavior of `keys()` in case of multiple values.