### PR TITLE
Miscellaneous improvements over #182

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.11.6",
+    "buffer-to-arraybuffer": "0.0.4",
     "encoding": "^0.1.11",
     "is-stream": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "bluebird": "^3.3.4",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
+    "chai-iterator": "^1.1.1",
     "coveralls": "^2.11.2",
     "cross-env": "2.0.1",
     "form-data": ">=1.0.0",

--- a/src/body.js
+++ b/src/body.js
@@ -7,6 +7,7 @@
 
 import {convert} from 'encoding';
 import bodyStream from 'is-stream';
+import toArrayBuffer from 'buffer-to-arraybuffer';
 import {PassThrough} from 'stream';
 import FetchError from './fetch-error.js';
 
@@ -33,6 +34,15 @@ export default class Body {
 
 	get bodyUsed() {
 		return this[DISTURBED];
+	}
+
+	/**
+	 * Decode response as ArrayBuffer
+	 *
+	 * @return  Promise
+	 */
+	arrayBuffer() {
+		return this[CONSUME_BODY]().then(buf => toArrayBuffer(buf));
 	}
 
 	/**

--- a/src/body.js
+++ b/src/body.js
@@ -79,6 +79,11 @@ export default class Body {
 
 		this[DISTURBED] = true;
 
+		// body is null
+		if (!this.body) {
+			return Body.Promise.resolve(new Buffer(0));
+		}
+
 		// body is string
 		if (typeof this.body === 'string') {
 			return Body.Promise.resolve(convertBody([new Buffer(this.body)], this.headers));

--- a/src/request.js
+++ b/src/request.js
@@ -5,7 +5,7 @@
  * Request class contains server only options
  */
 
-import { parse as parse_url } from 'url';
+import { format as format_url, parse as parse_url } from 'url';
 import Headers from './headers.js';
 import Body, { clone } from './body';
 
@@ -18,16 +18,14 @@ import Body, { clone } from './body';
  */
 export default class Request extends Body {
 	constructor(input, init = {}) {
-		let url, url_parsed;
+		let parsedURL;
 
 		// normalize input
 		if (!(input instanceof Request)) {
-			url = input;
-			url_parsed = parse_url(url);
+			parsedURL = parse_url(input);
 			input = {};
 		} else {
-			url = input.url;
-			url_parsed = parse_url(url);
+			parsedURL = parse_url(input.url);
 		}
 
 		super(init.body || clone(input), {
@@ -39,7 +37,6 @@ export default class Request extends Body {
 		this.method = init.method || input.method || 'GET';
 		this.redirect = init.redirect || input.redirect || 'follow';
 		this.headers = new Headers(init.headers || input.headers || {});
-		this.url = url;
 
 		// server only options
 		this.follow = init.follow !== undefined ?
@@ -52,11 +49,11 @@ export default class Request extends Body {
 		this.agent = init.agent || input.agent;
 
 		// server request options
-		this.protocol = url_parsed.protocol;
-		this.hostname = url_parsed.hostname;
-		this.port = url_parsed.port;
-		this.path = url_parsed.path;
-		this.auth = url_parsed.auth;
+		Object.assign(this, parsedURL);
+	}
+
+	get url() {
+		return format_url(this);
 	}
 
 	/**

--- a/src/response.js
+++ b/src/response.js
@@ -17,7 +17,7 @@ import Body, { clone } from './body';
  * @return  Void
  */
 export default class Response extends Body {
-	constructor(body, opts = {}) {
+	constructor(body = null, opts = {}) {
 		super(body, opts);
 
 		this.url = opts.url;

--- a/test/test.js
+++ b/test/test.js
@@ -1427,6 +1427,14 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should default to null as body', function() {
+		const res = new Response();
+		expect(res.body).to.equal(null);
+		return res.text().then(result => {
+			expect(result).to.equal('');
+		});
+	});
+
 	it('should default to 200 as status code', function() {
 		const res = new Response(null);
 		expect(res.status).to.equal(200);

--- a/test/test.js
+++ b/test/test.js
@@ -32,7 +32,7 @@ describe('node-fetch', () => {
 
 	before(done => {
 		local = new TestServer();
-		base = 'http://' + local.hostname + ':' + local.port;
+		base = `http://${local.hostname}:${local.port}/`;
 		local.start(done);
 	});
 
@@ -95,7 +95,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should resolve into response', function() {
-		url = `${base}/hello`;
+		url = `${base}hello`;
 		return fetch(url).then(res => {
 			expect(res).to.be.an.instanceof(Response);
 			expect(res.headers).to.be.an.instanceof(Headers);
@@ -110,7 +110,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should accept plain text response', function() {
-		url = `${base}/plain`;
+		url = `${base}plain`;
 		return fetch(url).then(res => {
 			expect(res.headers.get('content-type')).to.equal('text/plain');
 			return res.text().then(result => {
@@ -122,7 +122,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should accept html response (like plain text)', function() {
-		url = `${base}/html`;
+		url = `${base}html`;
 		return fetch(url).then(res => {
 			expect(res.headers.get('content-type')).to.equal('text/html');
 			return res.text().then(result => {
@@ -134,7 +134,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should accept json response', function() {
-		url = `${base}/json`;
+		url = `${base}json`;
 		return fetch(url).then(res => {
 			expect(res.headers.get('content-type')).to.equal('application/json');
 			return res.json().then(result => {
@@ -146,7 +146,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should send request with custom headers', function() {
-		url = `${base}/inspect`;
+		url = `${base}inspect`;
 		opts = {
 			headers: { 'x-custom-header': 'abc' }
 		};
@@ -158,7 +158,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should accept headers instance', function() {
-		url = `${base}/inspect`;
+		url = `${base}inspect`;
 		opts = {
 			headers: new Headers({ 'x-custom-header': 'abc' })
 		};
@@ -170,7 +170,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should accept custom host header', function() {
-		url = `${base}/inspect`;
+		url = `${base}inspect`;
 		opts = {
 			headers: {
 				host: 'example.com'
@@ -184,62 +184,62 @@ describe('node-fetch', () => {
 	});
 
 	it('should follow redirect code 301', function() {
-		url = `${base}/redirect/301`;
+		url = `${base}redirect/301`;
 		return fetch(url).then(res => {
-			expect(res.url).to.equal(`${base}/inspect`);
+			expect(res.url).to.equal(`${base}inspect`);
 			expect(res.status).to.equal(200);
 			expect(res.ok).to.be.true;
 		});
 	});
 
 	it('should follow redirect code 302', function() {
-		url = `${base}/redirect/302`;
+		url = `${base}redirect/302`;
 		return fetch(url).then(res => {
-			expect(res.url).to.equal(`${base}/inspect`);
+			expect(res.url).to.equal(`${base}inspect`);
 			expect(res.status).to.equal(200);
 		});
 	});
 
 	it('should follow redirect code 303', function() {
-		url = `${base}/redirect/303`;
+		url = `${base}redirect/303`;
 		return fetch(url).then(res => {
-			expect(res.url).to.equal(`${base}/inspect`);
+			expect(res.url).to.equal(`${base}inspect`);
 			expect(res.status).to.equal(200);
 		});
 	});
 
 	it('should follow redirect code 307', function() {
-		url = `${base}/redirect/307`;
+		url = `${base}redirect/307`;
 		return fetch(url).then(res => {
-			expect(res.url).to.equal(`${base}/inspect`);
+			expect(res.url).to.equal(`${base}inspect`);
 			expect(res.status).to.equal(200);
 		});
 	});
 
 	it('should follow redirect code 308', function() {
-		url = `${base}/redirect/308`;
+		url = `${base}redirect/308`;
 		return fetch(url).then(res => {
-			expect(res.url).to.equal(`${base}/inspect`);
+			expect(res.url).to.equal(`${base}inspect`);
 			expect(res.status).to.equal(200);
 		});
 	});
 
 	it('should follow redirect chain', function() {
-		url = `${base}/redirect/chain`;
+		url = `${base}redirect/chain`;
 		return fetch(url).then(res => {
-			expect(res.url).to.equal(`${base}/inspect`);
+			expect(res.url).to.equal(`${base}inspect`);
 			expect(res.status).to.equal(200);
 		});
 	});
 
 	it('should follow POST request redirect code 301 with GET', function() {
-		url = `${base}/redirect/301`;
+		url = `${base}redirect/301`;
 		opts = {
 			method: 'POST'
 			, body: 'a=1'
 		};
 		return fetch(url, opts).then(res => {
-			expect(res.url).to.equal(`${base}/inspect`);
+			expect(res.url).to.equal(`${base}inspect`);
 			expect(res.status).to.equal(200);
 			return res.json().then(result => {
 				expect(result.method).to.equal('GET');
@@ -249,13 +249,13 @@ describe('node-fetch', () => {
 	});
 
 	it('should follow POST request redirect code 302 with GET', function() {
-		url = `${base}/redirect/302`;
+		url = `${base}redirect/302`;
 		opts = {
 			method: 'POST'
 			, body: 'a=1'
 		};
 		return fetch(url, opts).then(res => {
-			expect(res.url).to.equal(`${base}/inspect`);
+			expect(res.url).to.equal(`${base}inspect`);
 			expect(res.status).to.equal(200);
 			return res.json().then(result => {
 				expect(result.method).to.equal('GET');
@@ -265,13 +265,13 @@ describe('node-fetch', () => {
 	});
 
 	it('should follow redirect code 303 with GET', function() {
-		url = `${base}/redirect/303`;
+		url = `${base}redirect/303`;
 		opts = {
 			method: 'PUT'
 			, body: 'a=1'
 		};
 		return fetch(url, opts).then(res => {
-			expect(res.url).to.equal(`${base}/inspect`);
+			expect(res.url).to.equal(`${base}inspect`);
 			expect(res.status).to.equal(200);
 			return res.json().then(result => {
 				expect(result.method).to.equal('GET');
@@ -281,7 +281,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should obey maximum redirect, reject case', function() {
-		url = `${base}/redirect/chain`;
+		url = `${base}redirect/chain`;
 		opts = {
 			follow: 1
 		}
@@ -291,18 +291,18 @@ describe('node-fetch', () => {
 	});
 
 	it('should obey redirect chain, resolve case', function() {
-		url = `${base}/redirect/chain`;
+		url = `${base}redirect/chain`;
 		opts = {
 			follow: 2
 		}
 		return fetch(url, opts).then(res => {
-			expect(res.url).to.equal(`${base}/inspect`);
+			expect(res.url).to.equal(`${base}inspect`);
 			expect(res.status).to.equal(200);
 		});
 	});
 
 	it('should allow not following redirect', function() {
-		url = `${base}/redirect/301`;
+		url = `${base}redirect/301`;
 		opts = {
 			follow: 0
 		}
@@ -312,19 +312,19 @@ describe('node-fetch', () => {
 	});
 
 	it('should support redirect mode, manual flag', function() {
-		url = `${base}/redirect/301`;
+		url = `${base}redirect/301`;
 		opts = {
 			redirect: 'manual'
 		};
 		return fetch(url, opts).then(res => {
 			expect(res.url).to.equal(url);
 			expect(res.status).to.equal(301);
-			expect(res.headers.get('location')).to.equal(`${base}/inspect`);
+			expect(res.headers.get('location')).to.equal(`${base}inspect`);
 		});
 	});
 
 	it('should support redirect mode, error flag', function() {
-		url = `${base}/redirect/301`;
+		url = `${base}redirect/301`;
 		opts = {
 			redirect: 'error'
 		};
@@ -334,7 +334,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should support redirect mode, manual flag when there is no redirect', function() {
-		url = `${base}/hello`;
+		url = `${base}hello`;
 		opts = {
 			redirect: 'manual'
 		};
@@ -346,12 +346,12 @@ describe('node-fetch', () => {
 	});
 
 	it('should follow redirect code 301 and keep existing headers', function() {
-		url = `${base}/redirect/301`;
+		url = `${base}redirect/301`;
 		opts = {
 			headers: new Headers({ 'x-custom-header': 'abc' })
 		};
 		return fetch(url, opts).then(res => {
-			expect(res.url).to.equal(`${base}/inspect`);
+			expect(res.url).to.equal(`${base}inspect`);
 			return res.json();
 		}).then(res => {
 			expect(res.headers['x-custom-header']).to.equal('abc');
@@ -359,14 +359,14 @@ describe('node-fetch', () => {
 	});
 
 	it('should reject broken redirect', function() {
-		url = `${base}/error/redirect`;
+		url = `${base}error/redirect`;
 		return expect(fetch(url)).to.eventually.be.rejected
 			.and.be.an.instanceOf(FetchError)
 			.and.have.property('type', 'invalid-redirect');
 	});
 
 	it('should not reject broken redirect under manual redirect', function() {
-		url = `${base}/error/redirect`;
+		url = `${base}error/redirect`;
 		opts = {
 			redirect: 'manual'
 		};
@@ -378,7 +378,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should handle client-error response', function() {
-		url = `${base}/error/400`;
+		url = `${base}error/400`;
 		return fetch(url).then(res => {
 			expect(res.headers.get('content-type')).to.equal('text/plain');
 			expect(res.status).to.equal(400);
@@ -393,7 +393,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should handle server-error response', function() {
-		url = `${base}/error/500`;
+		url = `${base}error/500`;
 		return fetch(url).then(res => {
 			expect(res.headers.get('content-type')).to.equal('text/plain');
 			expect(res.status).to.equal(500);
@@ -408,7 +408,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should handle network-error response', function() {
-		url = `${base}/error/reset`;
+		url = `${base}error/reset`;
 		return expect(fetch(url)).to.eventually.be.rejected
 			.and.be.an.instanceOf(FetchError)
 			.and.have.property('code', 'ECONNRESET');
@@ -422,7 +422,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should reject invalid json response', function() {
-		url = `${base}/error/json`;
+		url = `${base}error/json`;
 		return fetch(url).then(res => {
 			expect(res.headers.get('content-type')).to.equal('application/json');
 			return expect(res.json()).to.eventually.be.rejectedWith(Error);
@@ -430,7 +430,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should handle no content response', function() {
-		url = `${base}/no-content`;
+		url = `${base}no-content`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(204);
 			expect(res.statusText).to.equal('No Content');
@@ -443,7 +443,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should return empty object on no-content response', function() {
-		url = `${base}/no-content`;
+		url = `${base}no-content`;
 		return fetch(url).then(res => {
 			return res.json().then(result => {
 				expect(result).to.be.an('object');
@@ -453,7 +453,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should handle no content response with gzip encoding', function() {
-		url = `${base}/no-content/gzip`;
+		url = `${base}no-content/gzip`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(204);
 			expect(res.statusText).to.equal('No Content');
@@ -467,7 +467,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should handle not modified response', function() {
-		url = `${base}/not-modified`;
+		url = `${base}not-modified`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(304);
 			expect(res.statusText).to.equal('Not Modified');
@@ -480,7 +480,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should handle not modified response with gzip encoding', function() {
-		url = `${base}/not-modified/gzip`;
+		url = `${base}not-modified/gzip`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(304);
 			expect(res.statusText).to.equal('Not Modified');
@@ -494,7 +494,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should decompress gzip response', function() {
-		url = `${base}/gzip`;
+		url = `${base}gzip`;
 		return fetch(url).then(res => {
 			expect(res.headers.get('content-type')).to.equal('text/plain');
 			return res.text().then(result => {
@@ -505,7 +505,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should decompress deflate response', function() {
-		url = `${base}/deflate`;
+		url = `${base}deflate`;
 		return fetch(url).then(res => {
 			expect(res.headers.get('content-type')).to.equal('text/plain');
 			return res.text().then(result => {
@@ -516,7 +516,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should decompress deflate raw response from old apache server', function() {
-		url = `${base}/deflate-raw`;
+		url = `${base}deflate-raw`;
 		return fetch(url).then(res => {
 			expect(res.headers.get('content-type')).to.equal('text/plain');
 			return res.text().then(result => {
@@ -527,7 +527,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should skip decompression if unsupported', function() {
-		url = `${base}/sdch`;
+		url = `${base}sdch`;
 		return fetch(url).then(res => {
 			expect(res.headers.get('content-type')).to.equal('text/plain');
 			return res.text().then(result => {
@@ -538,7 +538,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should reject if response compression is invalid', function() {
-		url = `${base}/invalid-content-encoding`;
+		url = `${base}invalid-content-encoding`;
 		return fetch(url).then(res => {
 			expect(res.headers.get('content-type')).to.equal('text/plain');
 			return expect(res.text()).to.eventually.be.rejected
@@ -548,7 +548,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow disabling auto decompression', function() {
-		url = `${base}/gzip`;
+		url = `${base}gzip`;
 		opts = {
 			compress: false
 		};
@@ -563,7 +563,7 @@ describe('node-fetch', () => {
 
 	it('should allow custom timeout', function() {
 		this.timeout(500);
-		url = `${base}/timeout`;
+		url = `${base}timeout`;
 		opts = {
 			timeout: 100
 		};
@@ -574,7 +574,7 @@ describe('node-fetch', () => {
 
 	it('should allow custom timeout on response body', function() {
 		this.timeout(500);
-		url = `${base}/slow`;
+		url = `${base}slow`;
 		opts = {
 			timeout: 100
 		};
@@ -588,7 +588,7 @@ describe('node-fetch', () => {
 
 	it('should clear internal timeout on fetch response', function (done) {
 		this.timeout(1000);
-		spawn('node', ['-e', `require('./')('${base}/hello', { timeout: 5000 })`])
+		spawn('node', ['-e', `require('./')('${base}hello', { timeout: 5000 })`])
 			.on('exit', () => {
 				done();
 			});
@@ -596,7 +596,7 @@ describe('node-fetch', () => {
 
 	it('should clear internal timeout on fetch redirect', function (done) {
 		this.timeout(1000);
-		spawn('node', ['-e', `require('./')('${base}/redirect/301', { timeout: 5000 })`])
+		spawn('node', ['-e', `require('./')('${base}redirect/301', { timeout: 5000 })`])
 			.on('exit', () => {
 				done();
 			});
@@ -604,14 +604,14 @@ describe('node-fetch', () => {
 
 	it('should clear internal timeout on fetch error', function (done) {
 		this.timeout(1000);
-		spawn('node', ['-e', `require('./')('${base}/error/reset', { timeout: 5000 })`])
+		spawn('node', ['-e', `require('./')('${base}error/reset', { timeout: 5000 })`])
 			.on('exit', () => {
 				done();
 			});
 	});
 
 	it('should allow POST request', function() {
-		url = `${base}/inspect`;
+		url = `${base}inspect`;
 		opts = {
 			method: 'POST'
 		};
@@ -625,7 +625,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow POST request with string body', function() {
-		url = `${base}/inspect`;
+		url = `${base}inspect`;
 		opts = {
 			method: 'POST'
 			, body: 'a=1'
@@ -641,7 +641,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow POST request with buffer body', function() {
-		url = `${base}/inspect`;
+		url = `${base}inspect`;
 		opts = {
 			method: 'POST'
 			, body: new Buffer('a=1', 'utf-8')
@@ -660,7 +660,7 @@ describe('node-fetch', () => {
 		let body = resumer().queue('a=1').end();
 		body = body.pipe(new stream.PassThrough());
 
-		url = `${base}/inspect`;
+		url = `${base}inspect`;
 		opts = {
 			method: 'POST'
 			, body
@@ -679,7 +679,7 @@ describe('node-fetch', () => {
 		const form = new FormData();
 		form.append('a','1');
 
-		url = `${base}/multipart`;
+		url = `${base}multipart`;
 		opts = {
 			method: 'POST'
 			, body: form
@@ -698,7 +698,7 @@ describe('node-fetch', () => {
 		const form = new FormData();
 		form.append('my_field', fs.createReadStream('test/dummy.txt'));
 
-		url = `${base}/multipart`;
+		url = `${base}multipart`;
 		opts = {
 			method: 'POST'
 			, body: form
@@ -721,7 +721,7 @@ describe('node-fetch', () => {
 		const headers = form.getHeaders();
 		headers['b'] = '2';
 
-		url = `${base}/multipart`;
+		url = `${base}multipart`;
 		opts = {
 			method: 'POST'
 			, body: form
@@ -739,7 +739,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow POST request with object body', function() {
-		url = `${base}/inspect`;
+		url = `${base}inspect`;
 		// note that fetch simply calls tostring on an object
 		opts = {
 			method: 'POST'
@@ -754,7 +754,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow PUT request', function() {
-		url = `${base}/inspect`;
+		url = `${base}inspect`;
 		opts = {
 			method: 'PUT'
 			, body: 'a=1'
@@ -768,7 +768,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow DELETE request', function() {
-		url = `${base}/inspect`;
+		url = `${base}inspect`;
 		opts = {
 			method: 'DELETE'
 		};
@@ -780,7 +780,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow POST request with string body', function() {
-		url = `${base}/inspect`;
+		url = `${base}inspect`;
 		opts = {
 			method: 'POST'
 			, body: 'a=1'
@@ -796,7 +796,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow DELETE request with string body', function() {
-		url = `${base}/inspect`;
+		url = `${base}inspect`;
 		opts = {
 			method: 'DELETE'
 			, body: 'a=1'
@@ -812,7 +812,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow PATCH request', function() {
-		url = `${base}/inspect`;
+		url = `${base}inspect`;
 		opts = {
 			method: 'PATCH'
 			, body: 'a=1'
@@ -826,7 +826,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow HEAD request', function() {
-		url = `${base}/hello`;
+		url = `${base}hello`;
 		opts = {
 			method: 'HEAD'
 		};
@@ -842,7 +842,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow HEAD request with content-encoding header', function() {
-		url = `${base}/error/404`;
+		url = `${base}error/404`;
 		opts = {
 			method: 'HEAD'
 		};
@@ -856,7 +856,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow OPTIONS request', function() {
-		url = `${base}/options`;
+		url = `${base}options`;
 		opts = {
 			method: 'OPTIONS'
 		};
@@ -869,7 +869,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should reject decoding body twice', function() {
-		url = `${base}/plain`;
+		url = `${base}plain`;
 		return fetch(url).then(res => {
 			expect(res.headers.get('content-type')).to.equal('text/plain');
 			return res.text().then(result => {
@@ -880,7 +880,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should support maximum response size, multiple chunk', function() {
-		url = `${base}/size/chunk`;
+		url = `${base}size/chunk`;
 		opts = {
 			size: 5
 		};
@@ -894,7 +894,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should support maximum response size, single chunk', function() {
-		url = `${base}/size/long`;
+		url = `${base}size/long`;
 		opts = {
 			size: 5
 		};
@@ -908,7 +908,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should support encoding decode, xml dtd detect', function() {
-		url = `${base}/encoding/euc-jp`;
+		url = `${base}encoding/euc-jp`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
 			return res.text().then(result => {
@@ -918,7 +918,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should support encoding decode, content-type detect', function() {
-		url = `${base}/encoding/shift-jis`;
+		url = `${base}encoding/shift-jis`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
 			return res.text().then(result => {
@@ -928,7 +928,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should support encoding decode, html5 detect', function() {
-		url = `${base}/encoding/gbk`;
+		url = `${base}encoding/gbk`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
 			return res.text().then(result => {
@@ -938,7 +938,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should support encoding decode, html4 detect', function() {
-		url = `${base}/encoding/gb2312`;
+		url = `${base}encoding/gb2312`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
 			return res.text().then(result => {
@@ -948,7 +948,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should default to utf8 encoding', function() {
-		url = `${base}/encoding/utf8`;
+		url = `${base}encoding/utf8`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
 			expect(res.headers.get('content-type')).to.be.null;
@@ -959,7 +959,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should support uncommon content-type order, charset in front', function() {
-		url = `${base}/encoding/order1`;
+		url = `${base}encoding/order1`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
 			return res.text().then(result => {
@@ -969,7 +969,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should support uncommon content-type order, end with qs', function() {
-		url = `${base}/encoding/order2`;
+		url = `${base}encoding/order2`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
 			return res.text().then(result => {
@@ -979,7 +979,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should support chunked encoding, html4 detect', function() {
-		url = `${base}/encoding/chunked`;
+		url = `${base}encoding/chunked`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
 			const padding = 'a'.repeat(10);
@@ -990,7 +990,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should only do encoding detection up to 1024 bytes', function() {
-		url = `${base}/encoding/invalid`;
+		url = `${base}encoding/invalid`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
 			const padding = 'a'.repeat(1200);
@@ -1001,7 +1001,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow piping response body as stream', function(done) {
-		url = `${base}/hello`;
+		url = `${base}hello`;
 		fetch(url).then(res => {
 			expect(res.body).to.be.an.instanceof(stream.Transform);
 			res.body.on('data', chunk => {
@@ -1017,7 +1017,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow cloning a response, and use both as stream', function(done) {
-		url = `${base}/hello`;
+		url = `${base}hello`;
 		return fetch(url).then(res => {
 			let counter = 0;
 			const r1 = res.clone();
@@ -1051,7 +1051,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow cloning a json response and log it as text response', function() {
-		url = `${base}/json`;
+		url = `${base}json`;
 		return fetch(url).then(res => {
 			const r1 = res.clone();
 			return fetch.Promise.all([res.json(), r1.text()]).then(results => {
@@ -1062,7 +1062,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow cloning a json response, and then log it as text response', function() {
-		url = `${base}/json`;
+		url = `${base}json`;
 		return fetch(url).then(res => {
 			const r1 = res.clone();
 			return res.json().then(result => {
@@ -1075,7 +1075,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow cloning a json response, first log as text response, then return json object', function() {
-		url = `${base}/json`;
+		url = `${base}json`;
 		return fetch(url).then(res => {
 			const r1 = res.clone();
 			return r1.text().then(result => {
@@ -1088,7 +1088,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should not allow cloning a response after its been used', function() {
-		url = `${base}/hello`;
+		url = `${base}hello`;
 		return fetch(url).then(res =>
 			res.text().then(result => {
 				expect(() => {
@@ -1099,7 +1099,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow get all responses of a header', function() {
-		url = `${base}/cookie`;
+		url = `${base}cookie`;
 		return fetch(url).then(res => {
 			expect(res.headers.get('set-cookie')).to.equal('a=1');
 			expect(res.headers.get('Set-Cookie')).to.equal('a=1');
@@ -1190,7 +1190,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow deleting header', function() {
-		url = `${base}/cookie`;
+		url = `${base}cookie`;
 		return fetch(url).then(res => {
 			res.headers.delete('set-cookie');
 			expect(res.headers.get('set-cookie')).to.be.null;
@@ -1199,7 +1199,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should send request with connection keep-alive if agent is provided', function() {
-		url = `${base}/inspect`;
+		url = `${base}inspect`;
 		opts = {
 			agent: new http.Agent({
 				keepAlive: true
@@ -1286,7 +1286,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should support fetch with Request instance', function() {
-		url = `${base}/hello`;
+		url = `${base}hello`;
 		const req = new Request(url);
 		return fetch(req).then(res => {
 			expect(res.url).to.equal(url);
@@ -1296,7 +1296,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should support wrapping Request instance', function() {
-		url = `${base}/hello`;
+		url = `${base}hello`;
 
 		const form = new FormData();
 		form.append('a', '1');
@@ -1321,7 +1321,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should support overwrite Request instance', function() {
-		url = `${base}/inspect`;
+		url = `${base}inspect`;
 		const req = new Request(url, {
 			method: 'POST'
 			, headers: {

--- a/test/test.js
+++ b/test/test.js
@@ -171,6 +171,11 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should support proper toString output for Headers instance', function() {
+		const headers = new Headers();
+		expect(headers.toString()).to.equal('[object Headers]');
+	});
+
 	it('should accept custom host header', function() {
 		url = `${base}inspect`;
 		opts = {
@@ -1300,6 +1305,11 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should support proper toString output for Request instance', function() {
+		const req = new Request(base);
+		expect(req.toString()).to.equal('[object Request]');
+	});
+
 	it('should support wrapping Request instance', function() {
 		url = `${base}hello`;
 
@@ -1353,6 +1363,11 @@ describe('node-fetch', () => {
 		return res.text().then(result => {
 			expect(result).to.equal('a=1');
 		});
+	});
+
+	it('should support proper toString output for Response instance', function() {
+		const res = new Response();
+		expect(res.toString()).to.equal('[object Response]');
 	});
 
 	it('should support parsing headers in Response constructor', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,8 @@
 
 // test tools
 import chai from 'chai';
-import cap from 'chai-as-promised';
+import chaiPromised from 'chai-as-promised';
+import chaiIterator from 'chai-iterator';
 import bluebird from 'bluebird';
 import then from 'promise';
 import {spawn} from 'child_process';
@@ -11,7 +12,8 @@ import FormData from 'form-data';
 import * as http from 'http';
 import * as fs from 'fs';
 
-chai.use(cap);
+chai.use(chaiPromised);
+chai.use(chaiIterator);
 const expect = chai.expect;
 
 import TestServer from './server';
@@ -1108,7 +1110,7 @@ describe('node-fetch', () => {
 		});
 	});
 
-	it('should allow iterating through all headers', function() {
+	it('should allow iterating through all headers with forEach', function() {
 		const headers = new Headers({
 			a: 1
 			, b: [2, 3]
@@ -1130,63 +1132,66 @@ describe('node-fetch', () => {
 		expect(result).to.deep.equal(expected);
 	});
 
-	it('should allow iterating through all headers', function() {
+	it('should allow iterating through all headers with for-of loop', function() {
 		const headers = new Headers({
-			a: 1
-			, b: [2, 3]
-			, c: [4]
+			a: '1'
+			, b: '2'
+			, c: '4'
 		});
-		expect(headers).to.have.property(Symbol.iterator);
-		expect(headers).to.have.property('keys');
-		expect(headers).to.have.property('values');
-		expect(headers).to.have.property('entries');
+		headers.append('b', '3');
+		expect(headers).to.be.iterable;
 
-		let result, expected;
-
-		result = [];
-		for (let [key, val] of headers) {
-			result.push([key, val]);
+		const result = [];
+		for (let pair of headers) {
+			result.push(pair);
 		}
-
-		expected = [
+		expect(result).to.deep.equal([
 			["a", "1"]
 			, ["b", "2"]
 			, ["b", "3"]
 			, ["c", "4"]
-		];
-		expect(result).to.deep.equal(expected);
+		]);
+	});
 
-		result = [];
-		for (let [key, val] of headers.entries()) {
-			result.push([key, val]);
-		}
-		expect(result).to.deep.equal(expected);
+	it('should allow iterating through all headers with entries()', function() {
+		const headers = new Headers({
+			a: '1'
+			, b: '2'
+			, c: '4'
+		});
+		headers.append('b', '3');
 
-		result = [];
-		for (let key of headers.keys()) {
-			result.push(key);
-		}
+		expect(headers.entries()).to.be.iterable
+			.and.to.deep.iterate.over([
+				["a", "1"]
+				, ["b", "2"]
+				, ["b", "3"]
+				, ["c", "4"]
+			]);
+	});
 
-		expected = [
-			"a"
-			, "b"
-			, "b"
-			, "c"
-		];
-		expect(result).to.deep.equal(expected);
+	it('should allow iterating through all headers with keys()', function() {
+		const headers = new Headers({
+			a: '1'
+			, b: '2'
+			, c: '4'
+		});
+		headers.append('b', '3');
 
-		result = [];
-		for (let key of headers.values()) {
-			result.push(key);
-		}
+		expect(headers.keys()).to.be.iterable
+			.and.to.iterate.over(['a', 'b', 'b', 'c']);
+	});
 
-		expected = [
-			"1"
-			, "2"
-			, "3"
-			, "4"
-		];
-		expect(result).to.deep.equal(expected);
+	it('should allow iterating through all headers with values()', function() {
+		const headers = new Headers({
+			a: '1'
+			, b: '2'
+			, c: '4'
+		});
+		headers.append('b', '3');
+
+		expect(headers.values()).to.be.iterable
+			.and.to.iterate.over(['1', '2', '3', '4']);
 	});
 
 	it('should allow deleting header', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -1451,6 +1451,19 @@ describe('node-fetch', () => {
 		expect(req.headers.get('a')).to.equal('1');
 	});
 
+	it('should support arrayBuffer() method in Request constructor', function() {
+		url = base;
+		var req = new Request(url, {
+			body: 'a=1'
+		});
+		expect(req.url).to.equal(url);
+		return req.arrayBuffer().then(function(result) {
+			expect(result).to.be.an.instanceOf(ArrayBuffer);
+			const str = String.fromCharCode.apply(null, new Uint8Array(result));
+			expect(str).to.equal('a=1');
+		});
+	});
+
 	it('should support text() method in Request constructor', function() {
 		url = base;
 		const req = new Request(url, {
@@ -1524,8 +1537,9 @@ describe('node-fetch', () => {
 		});
 	});
 
-	it('should support text(), json() and buffer() method in Body constructor', function() {
+	it('should support arrayBuffer(), text(), json() and buffer() method in Body constructor', function() {
 		const body = new Body('a=1');
+		expect(body).to.have.property('arrayBuffer');
 		expect(body).to.have.property('text');
 		expect(body).to.have.property('json');
 		expect(body).to.have.property('buffer');


### PR DESCRIPTION
* Simplify `Request` and `Body` classes
* Add support for `body.arrayBuffer()` (using [buffer-to-arraybuffer](https://www.npmjs.com/package/buffer-to-arraybuffer) to gain support on older Node.js compared to #140)
* Fix spec compliance when body is `null`
* Add more tests