### PR TITLE
Improve Headers compatibility

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -1,0 +1,111 @@
+/**
+ * A set of utilities borrowed from Node.js' _http_common.js
+ */
+
+/**
+ * Verifies that the given val is a valid HTTP token
+ * per the rules defined in RFC 7230
+ * See https://tools.ietf.org/html/rfc7230#section-3.2.6
+ *
+ * Allowed characters in an HTTP token:
+ * ^_`a-z  94-122
+ * A-Z     65-90
+ * -       45
+ * 0-9     48-57
+ * !       33
+ * #$%&'   35-39
+ * *+      42-43
+ * .       46
+ * |       124
+ * ~       126
+ *
+ * This implementation of checkIsHttpToken() loops over the string instead of
+ * using a regular expression since the former is up to 180% faster with v8 4.9
+ * depending on the string length (the shorter the string, the larger the
+ * performance difference)
+ *
+ * Additionally, checkIsHttpToken() is currently designed to be inlinable by v8,
+ * so take care when making changes to the implementation so that the source
+ * code size does not exceed v8's default max_inlined_source_size setting.
+ **/
+/* istanbul ignore next */
+function isValidTokenChar(ch) {
+  if (ch >= 94 && ch <= 122)
+    return true;
+  if (ch >= 65 && ch <= 90)
+    return true;
+  if (ch === 45)
+    return true;
+  if (ch >= 48 && ch <= 57)
+    return true;
+  if (ch === 34 || ch === 40 || ch === 41 || ch === 44)
+    return false;
+  if (ch >= 33 && ch <= 46)
+    return true;
+  if (ch === 124 || ch === 126)
+    return true;
+  return false;
+}
+/* istanbul ignore next */
+function checkIsHttpToken(val) {
+  if (typeof val !== 'string' || val.length === 0)
+    return false;
+  if (!isValidTokenChar(val.charCodeAt(0)))
+    return false;
+  const len = val.length;
+  if (len > 1) {
+    if (!isValidTokenChar(val.charCodeAt(1)))
+      return false;
+    if (len > 2) {
+      if (!isValidTokenChar(val.charCodeAt(2)))
+        return false;
+      if (len > 3) {
+        if (!isValidTokenChar(val.charCodeAt(3)))
+          return false;
+        for (var i = 4; i < len; i++) {
+          if (!isValidTokenChar(val.charCodeAt(i)))
+            return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+exports._checkIsHttpToken = checkIsHttpToken;
+
+/**
+ * True if val contains an invalid field-vchar
+ *  field-value    = *( field-content / obs-fold )
+ *  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+ *  field-vchar    = VCHAR / obs-text
+ *
+ * checkInvalidHeaderChar() is currently designed to be inlinable by v8,
+ * so take care when making changes to the implementation so that the source
+ * code size does not exceed v8's default max_inlined_source_size setting.
+ **/
+/* istanbul ignore next */
+function checkInvalidHeaderChar(val) {
+  val += '';
+  if (val.length < 1)
+    return false;
+  var c = val.charCodeAt(0);
+  if ((c <= 31 && c !== 9) || c > 255 || c === 127)
+    return true;
+  if (val.length < 2)
+    return false;
+  c = val.charCodeAt(1);
+  if ((c <= 31 && c !== 9) || c > 255 || c === 127)
+    return true;
+  if (val.length < 3)
+    return false;
+  c = val.charCodeAt(2);
+  if ((c <= 31 && c !== 9) || c > 255 || c === 127)
+    return true;
+  for (var i = 3; i < val.length; ++i) {
+    c = val.charCodeAt(i);
+    if ((c <= 31 && c !== 9) || c > 255 || c === 127)
+      return true;
+  }
+  return false;
+}
+exports._checkInvalidHeaderChar = checkInvalidHeaderChar;

--- a/src/headers.js
+++ b/src/headers.js
@@ -17,7 +17,15 @@ export default class Headers {
 	constructor(headers) {
 		this[MAP] = {};
 
-		if (Array.isArray(headers)) {
+		// Headers
+		if (headers instanceof Headers) {
+		  let init = headers.raw();
+		  for (let name of Object.keys(init)) {
+		    for (let value of init[name]) {
+		      this.append(name, value);
+		    }
+		  }
+		} else if (Array.isArray(headers)) {
 			// array of tuples
 			for (let el of headers) {
 				if (!Array.isArray(el) || el.length !== 2) {
@@ -25,28 +33,12 @@ export default class Headers {
 				}
 				this.append(el[0], el[1]);
 			}
-			return;
-		}
-
-               // Headers
-		if (headers instanceof Headers) {
-			headers = headers.raw();
-		}
-
-		// plain object
-		for (const prop in headers) {
-			if (!headers.hasOwnProperty(prop)) {
-				continue;
-			}
-
-			if (typeof headers[prop] === 'string') {
-				this.set(prop, headers[prop]);
-			} else if (typeof headers[prop] === 'number' && !isNaN(headers[prop])) {
-				this.set(prop, headers[prop].toString());
-			} else if (headers[prop] instanceof Array) {
-				headers[prop].forEach(item => {
-					this.append(prop, item.toString());
-				});
+		} else if (typeof headers === 'object') {
+			// plain object
+			for (const prop of Object.keys(headers)) {
+				// We don't worry about converting prop to ByteString here as append()
+				// will handle it.
+				this.append(prop, headers[prop]);
 			}
 		}
 	}
@@ -99,6 +91,9 @@ export default class Headers {
 	 * @return  Void
 	 */
 	set(name, value) {
+		name += '';
+		value += '';
+
 		this[MAP][name.toLowerCase()] = [value];
 	}
 
@@ -110,6 +105,9 @@ export default class Headers {
 	 * @return  Void
 	 */
 	append(name, value) {
+		name += '';
+		value += '';
+
 		if (!this.has(name)) {
 			this.set(name, value);
 			return;

--- a/src/headers.js
+++ b/src/headers.js
@@ -5,6 +5,7 @@
  * Headers class offers convenient helpers
  */
 
+import getIterator from 'babel-runtime/core-js/get-iterator';
 import { _checkIsHttpToken, _checkInvalidHeaderChar } from './common.js';
 
 function sanitizeName(name) {
@@ -174,7 +175,7 @@ export default class Headers {
 		} else {
 			this.forEach((_, name) => keys.push(name));
 		};
-		return new Iterator(keys);
+		return getIterator(keys);
 	}
 
 	/**
@@ -190,7 +191,7 @@ export default class Headers {
 		} else {
 			const values = [];
 			this.forEach(value => values.push(value));
-			yield* new Iterator(values);
+			yield* getIterator(values);
 		}
 	}
 
@@ -207,7 +208,7 @@ export default class Headers {
 		} else {
 			const entries = [];
 			this.forEach((value, name) => entries.push([name, value]));
-			yield* new Iterator(entries);
+			yield* getIterator(entries);
 		}
 	}
 
@@ -231,29 +232,3 @@ export default class Headers {
 }
 
 Headers.FOLLOW_SPEC = false;
-
-const ITEMS = Symbol('items');
-class Iterator {
-	constructor(items) {
-		this[ITEMS] = items;
-	}
-
-	next() {
-		if (!this[ITEMS].length) {
-			return {
-				value: undefined,
-				done: true
-			};
-		}
-
-		return {
-			value: this[ITEMS].shift(),
-			done: false
-		};
-
-	}
-
-	[Symbol.iterator]() {
-		return this;
-	}
-}

--- a/src/headers.js
+++ b/src/headers.js
@@ -5,8 +5,25 @@
  * Headers class offers convenient helpers
  */
 
-export const MAP = Symbol('map');
+import { _checkIsHttpToken, _checkInvalidHeaderChar } from './common.js';
 
+function sanitizeName(name) {
+	name += '';
+	if (!_checkIsHttpToken(name)) {
+		throw new TypeError(`${name} is not a legal HTTP header name`);
+	}
+	return name.toLowerCase();
+}
+
+function sanitizeValue(value) {
+	value += '';
+	if (_checkInvalidHeaderChar(value)) {
+		throw new TypeError(`${value} is not a legal HTTP header value`);
+	}
+	return value;
+}
+
+export const MAP = Symbol('map');
 export default class Headers {
 	/**
 	 * Headers class
@@ -50,7 +67,7 @@ export default class Headers {
 	 * @return  Mixed
 	 */
 	get(name) {
-		const list = this[MAP][name.toLowerCase()];
+		const list = this[MAP][sanitizeName(name)];
 		return list ? list[0] : null;
 	}
 
@@ -65,7 +82,7 @@ export default class Headers {
 			return [];
 		}
 
-		return this[MAP][name.toLowerCase()];
+		return this[MAP][sanitizeName(name)];
 	}
 
 	/**
@@ -91,10 +108,7 @@ export default class Headers {
 	 * @return  Void
 	 */
 	set(name, value) {
-		name += '';
-		value += '';
-
-		this[MAP][name.toLowerCase()] = [value];
+		this[MAP][sanitizeName(name)] = [sanitizeValue(value)];
 	}
 
 	/**
@@ -105,15 +119,12 @@ export default class Headers {
 	 * @return  Void
 	 */
 	append(name, value) {
-		name += '';
-		value += '';
-
 		if (!this.has(name)) {
 			this.set(name, value);
 			return;
 		}
 
-		this[MAP][name.toLowerCase()].push(value);
+		this[MAP][sanitizeName(name)].push(sanitizeValue(value));
 	}
 
 	/**
@@ -123,7 +134,7 @@ export default class Headers {
 	 * @return  Boolean
 	 */
 	has(name) {
-		return this[MAP].hasOwnProperty(name.toLowerCase());
+		return this[MAP].hasOwnProperty(sanitizeName(name));
 	}
 
 	/**
@@ -133,7 +144,7 @@ export default class Headers {
 	 * @return  Void
 	 */
 	delete(name) {
-		delete this[MAP][name.toLowerCase()];
+		delete this[MAP][sanitizeName(name)];
 	};
 
 	/**

--- a/src/headers.js
+++ b/src/headers.js
@@ -17,7 +17,18 @@ export default class Headers {
 	constructor(headers) {
 		this[MAP] = {};
 
-		// Headers
+		if (Array.isArray(headers)) {
+			// array of tuples
+			for (let el of headers) {
+				if (!Array.isArray(el) || el.length !== 2) {
+					throw new TypeError('Header pairs must contain exactly two items');
+				}
+				this.append(el[0], el[1]);
+			}
+			return;
+		}
+
+               // Headers
 		if (headers instanceof Headers) {
 			headers = headers.raw();
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ function fetch(url, opts) {
 	}
 
 	Body.Promise = fetch.Promise;
+	Headers.FOLLOW_SPEC = fetch.FOLLOW_SPEC;
 
 	// wrap http.request into fetch
 	return new fetch.Promise((resolve, reject) => {
@@ -258,6 +259,15 @@ fetch.isRedirect = code => code === 301 || code === 302 || code === 303 || code 
 
 // expose Promise
 fetch.Promise = global.Promise;
+/**
+ * Option to make newly constructed Headers objects conformant to the
+ * **latest** version of the Fetch Standard. Note, that most other
+ * implementations of fetch() have not yet been updated to the latest
+ * version, so enabling this option almost certainly breaks any isomorphic
+ * attempt. Also, changing this variable will only affect new Headers
+ * objects; existing objects are not affected.
+ */
+fetch.FOLLOW_SPEC = false;
 fetch.Response = Response;
 fetch.Headers = Headers;
 fetch.Request = Request;

--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,16 @@ function fetch(url, opts) {
 			}
 
 			// normalize location header for manual redirect mode
-			const headers = new Headers(res.headers);
+			const headers = new Headers();
+			for (const name of Object.keys(res.headers)) {
+				if (Array.isArray(res.headers[name])) {
+					for (const val of res.headers[name]) {
+						headers.append(name, val);
+					}
+				} else {
+					headers.append(name, res.headers[name]);
+				}
+			}
 			if (options.redirect === 'manual' && headers.has('location')) {
 				headers.set('location', resolve_url(options.url, headers.get('location')));
 			}

--- a/test/test.js
+++ b/test/test.js
@@ -1207,6 +1207,22 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should reject illegal header', function() {
+		const headers = new Headers();
+		expect(() => new Headers({ 'He y': 'ok' })).to.throw(TypeError);
+		expect(() => new Headers({ 'Hé-y': 'ok' })).to.throw(TypeError);
+		expect(() => new Headers({ 'He-y': 'ăk' })).to.throw(TypeError);
+		expect(() => headers.append('Hé-y', 'ok')) .to.throw(TypeError);
+		expect(() => headers.delete('Hé-y'))       .to.throw(TypeError);
+		expect(() => headers.get('Hé-y'))          .to.throw(TypeError);
+		expect(() => headers.getAll('Hé-y'))       .to.throw(TypeError);
+		expect(() => headers.has('Hé-y'))          .to.throw(TypeError);
+		expect(() => headers.set('Hé-y', 'ok'))    .to.throw(TypeError);
+
+		// 'o k' is valid value but invalid name
+		new Headers({ 'He-y': 'o k' });
+	});
+
 	it('should send request with connection keep-alive if agent is provided', function() {
 		url = `${base}inspect`;
 		opts = {

--- a/test/test.js
+++ b/test/test.js
@@ -1295,6 +1295,21 @@ describe('node-fetch', () => {
 		expect(h3Raw['b']).to.include('1');
 	});
 
+	it('should accept headers as an array of tuples', function() {
+		const headers = new Headers([
+			['a', '1'],
+			['b', '2'],
+			['a', '3']
+		]);
+		expect(headers.getAll('a')).to.deep.equal(['1', '3']);
+		expect(headers.getAll('b')).to.deep.equal(['2']);
+	});
+
+	it('should throw a TypeError if non-tuple exists in a headers initializer', function() {
+		expect(() => new Headers([ ['b', '2', 'huh?'] ])).to.throw(TypeError);
+		expect(() => new Headers([ 'b2' ])).to.throw(TypeError);
+	});
+
 	it('should support fetch with Request instance', function() {
 		url = `${base}hello`;
 		const req = new Request(url);

--- a/test/test.js
+++ b/test/test.js
@@ -28,18 +28,26 @@ import FetchError from '../src/fetch-error.js';
 // test with native promise on node 0.11, and bluebird for node 0.10
 fetch.Promise = fetch.Promise || bluebird;
 
-let url, opts, local, base;
+const local = new TestServer();
+const base = `http://${local.hostname}:${local.port}/`;
+let url, opts;
 
-describe('node-fetch', () => {
+before(done => {
+	local.start(done);
+});
 
-	before(done => {
-		local = new TestServer();
-		base = `http://${local.hostname}:${local.port}/`;
-		local.start(done);
-	});
+after(done => {
+	local.stop(done);
+});
 
-	after(done => {
-		local.stop(done);
+(runner => {
+	runner(false);
+	runner(true);
+})(defaultFollowSpec => {
+
+describe(`node-fetch with FOLLOW_SPEC = ${defaultFollowSpec}`, () => {
+	before(() => {
+		fetch.FOLLOW_SPEC = Headers.FOLLOW_SPEC = defaultFollowSpec;
 	});
 
 	it('should return a promise', function() {
@@ -1108,8 +1116,9 @@ describe('node-fetch', () => {
 	it('should allow get all responses of a header', function() {
 		url = `${base}cookie`;
 		return fetch(url).then(res => {
-			expect(res.headers.get('set-cookie')).to.equal('a=1');
-			expect(res.headers.get('Set-Cookie')).to.equal('a=1');
+			const expected = fetch.FOLLOW_SPEC ? 'a=1,b=1' : 'a=1';
+			expect(res.headers.get('set-cookie')).to.equal(expected);
+			expect(res.headers.get('Set-Cookie')).to.equal(expected);
 			expect(res.headers.getAll('set-cookie')).to.deep.equal(['a=1', 'b=1']);
 			expect(res.headers.getAll('Set-Cookie')).to.deep.equal(['a=1', 'b=1']);
 		});
@@ -1137,11 +1146,11 @@ describe('node-fetch', () => {
 	});
 
 	it('should allow iterating through all headers with for-of loop', function() {
-		const headers = new Headers({
-			a: '1'
-			, b: '2'
-			, c: '4'
-		});
+		const headers = new Headers([
+			['b', '2'],
+			['c', '4'],
+			['a', '1']
+		]);
 		headers.append('b', '3');
 		expect(headers).to.be.iterable;
 
@@ -1149,53 +1158,81 @@ describe('node-fetch', () => {
 		for (let pair of headers) {
 			result.push(pair);
 		}
-		expect(result).to.deep.equal([
-			["a", "1"]
-			, ["b", "2"]
-			, ["b", "3"]
-			, ["c", "4"]
+		expect(result).to.deep.equal(Headers.FOLLOW_SPEC ? [
+			['a', '1'],
+			['b', '2,3'],
+			['c', '4']
+		] : [
+		  ['b', '2'],
+			['b', '3'],
+			['c', '4'],
+			['a', '1'],
 		]);
 	});
 
 	it('should allow iterating through all headers with entries()', function() {
-		const headers = new Headers({
-			a: '1'
-			, b: '2'
-			, c: '4'
-		});
+		const headers = new Headers([
+			['b', '2'],
+			['c', '4'],
+			['a', '1']
+		]);
 		headers.append('b', '3');
 
 		expect(headers.entries()).to.be.iterable
-			.and.to.deep.iterate.over([
-				["a", "1"]
-				, ["b", "2"]
-				, ["b", "3"]
-				, ["c", "4"]
+			.and.to.deep.iterate.over(Headers.FOLLOW_SPEC ? [
+				['a', '1'],
+				['b', '2,3'],
+				['c', '4']
+			] : [
+				['b', '2'],
+				['b', '3'],
+				['c', '4'],
+				['a', '1'],
 			]);
 	});
 
 	it('should allow iterating through all headers with keys()', function() {
-		const headers = new Headers({
-			a: '1'
-			, b: '2'
-			, c: '4'
-		});
+		const headers = new Headers([
+			['b', '2'],
+			['c', '4'],
+			['a', '1']
+		]);
 		headers.append('b', '3');
 
 		expect(headers.keys()).to.be.iterable
-			.and.to.iterate.over(['a', 'b', 'b', 'c']);
+			.and.to.iterate.over(Headers.FOLLOW_SPEC ? ['a', 'b', 'c'] : ['b', 'b', 'c', 'a']);
 	});
 
 	it('should allow iterating through all headers with values()', function() {
-		const headers = new Headers({
-			a: '1'
-			, b: '2'
-			, c: '4'
-		});
+		const headers = new Headers([
+			['b', '2'],
+			['c', '4'],
+			['a', '1']
+		]);
 		headers.append('b', '3');
 
 		expect(headers.values()).to.be.iterable
-			.and.to.iterate.over(['1', '2', '3', '4']);
+			.and.to.iterate.over(Headers.FOLLOW_SPEC ? ['1', '2,3', '4'] : ['2', '3', '4', '1']);
+	});
+
+	it('should only apply FOLLOW_SPEC when it is requested', function () {
+		Headers.FOLLOW_SPEC = true;
+
+		const src = [
+			['b', '2'],
+			['b', '3']
+		];
+
+		let headers = new Headers(src);
+		expect(headers.get('b')).to.equal('2,3');
+
+		Headers.FOLLOW_SPEC = false;
+		expect(headers.get('b')).to.equal('2,3');
+
+		headers = new Headers(src);
+		expect(headers.get('b')).to.equal('2');
+
+		Headers.FOLLOW_SPEC = defaultFollowSpec;
 	});
 
 	it('should allow deleting header', function() {
@@ -1619,5 +1656,7 @@ describe('node-fetch', () => {
 			expect(res.ok).to.be.true;
 		});
 	});
+
+});
 
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1130,8 +1130,7 @@ describe('node-fetch', () => {
 
 		const expected = [
 			["a", "1"]
-			, ["b", "2"]
-			, ["b", "3"]
+			, ["b", "2,3"]
 			, ["c", "4"]
 		];
 		expect(result).to.deep.equal(expected);
@@ -1223,20 +1222,18 @@ describe('node-fetch', () => {
 	});
 
 	it('should ignore unsupported attributes while reading headers', function() {
-		const FakeHeader = () => {};
-		// prototypes are ignored
+		const FakeHeader = function () {};
+		// prototypes are currently ignored
+		// This might change in the future: #181
 		FakeHeader.prototype.z = 'fake';
 
 		const res = new FakeHeader;
-		// valid
 		res.a = 'string';
 		res.b = ['1','2'];
 		res.c = '';
 		res.d = [];
-		// common mistakes, normalized
 		res.e = 1;
 		res.f = [1, 2];
-		// invalid, ignored
 		res.g = { a:1 };
 		res.h = undefined;
 		res.i = null;
@@ -1246,25 +1243,26 @@ describe('node-fetch', () => {
 		res.m = new Buffer('test');
 
 		const h1 = new Headers(res);
+		h1.set('n', [1, 2]);
+		h1.append('n', ['3', 4])
+
 		const h1Raw = h1.raw();
 
 		expect(h1Raw['a']).to.include('string');
-		expect(h1Raw['b']).to.include('1');
-		expect(h1Raw['b']).to.include('2');
+		expect(h1Raw['b']).to.include('1,2');
 		expect(h1Raw['c']).to.include('');
-		expect(h1Raw['d']).to.be.undefined;
-
+		expect(h1Raw['d']).to.include('');
 		expect(h1Raw['e']).to.include('1');
-		expect(h1Raw['f']).to.include('1');
-		expect(h1Raw['f']).to.include('2');
-
-		expect(h1Raw['g']).to.be.undefined;
-		expect(h1Raw['h']).to.be.undefined;
-		expect(h1Raw['i']).to.be.undefined;
-		expect(h1Raw['j']).to.be.undefined;
-		expect(h1Raw['k']).to.be.undefined;
-		expect(h1Raw['l']).to.be.undefined;
-		expect(h1Raw['m']).to.be.undefined;
+		expect(h1Raw['f']).to.include('1,2');
+		expect(h1Raw['g']).to.include('[object Object]');
+		expect(h1Raw['h']).to.include('undefined');
+		expect(h1Raw['i']).to.include('null');
+		expect(h1Raw['j']).to.include('NaN');
+		expect(h1Raw['k']).to.include('true');
+		expect(h1Raw['l']).to.include('false');
+		expect(h1Raw['m']).to.include('test');
+		expect(h1Raw['n']).to.include('1,2');
+		expect(h1Raw['n']).to.include('3,4');
 
 		expect(h1Raw['z']).to.be.undefined;
 	});


### PR DESCRIPTION
Fixes #181. I did add a `FOLLOW_SPEC` option, and made the test suite run twice -- once with `FOLLOW_SPEC` enabled and once disabled. To use it one would do:

```js
const fetch = require('node-fetch');
fetch.FOLLOW_SPEC = true;
```