### PR TITLE
Support WHATWG URL objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "nyc": "^8.3.0",
     "parted": "^0.1.1",
     "promise": "^7.1.1",
-    "resumer": "0.0.0"
+    "resumer": "0.0.0",
+    "whatwg-url": "^3.0.0"
   },
   "dependencies": {
     "babel-runtime": "^6.11.6",
@@ -53,7 +54,12 @@
   },
   "babel": {
     "presets": [
-      ["es2015", {"loose": true}]
+      [
+        "es2015",
+        {
+          "loose": true
+        }
+      ]
     ],
     "plugins": [
       "transform-runtime"

--- a/src/request.js
+++ b/src/request.js
@@ -22,7 +22,15 @@ export default class Request extends Body {
 
 		// normalize input
 		if (!(input instanceof Request)) {
-			parsedURL = parse_url(input);
+			if (input && input.href) {
+				// in order to support Node.js' Url objects; though WHATWG's URL objects
+				// will fall into this branch also (since their `toString()` will return
+				// `href` property anyway)
+				parsedURL = parse_url(input.href);
+			} else {
+				// coerce input to a string before attempting to parse
+				parsedURL = parse_url(input + '');
+			}
 			input = {};
 		} else {
 			parsedURL = parse_url(input.url);

--- a/test/test.js
+++ b/test/test.js
@@ -29,6 +29,12 @@ import FetchError from '../src/fetch-error.js';
 // test with native promise on node 0.11, and bluebird for node 0.10
 fetch.Promise = fetch.Promise || bluebird;
 
+let URL;
+// whatwg-url doesn't support old Node.js, so make it optional
+try {
+	URL = require('whatwg-url').URL;
+} catch (err) {}
+
 const local = new TestServer();
 const base = `http://${local.hostname}:${local.port}/`;
 let url, opts;
@@ -1386,6 +1392,17 @@ describe(`node-fetch with FOLLOW_SPEC = ${defaultFollowSpec}`, () => {
 	it('should support fetch with Node.js URL object', function() {
 		url = `${base}hello`;
 		const urlObj = parseURL(url);
+		const req = new Request(urlObj);
+		return fetch(req).then(res => {
+			expect(res.url).to.equal(url);
+			expect(res.ok).to.be.true;
+			expect(res.status).to.equal(200);
+		});
+	});
+
+	(URL ? it : it.skip)('should support fetch with WHATWG URL object', function() {
+		url = `${base}hello`;
+		const urlObj = new URL(url);
 		const req = new Request(urlObj);
 		return fetch(req).then(res => {
 			expect(res.url).to.equal(url);

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,7 @@ import {spawn} from 'child_process';
 import * as stream from 'stream';
 import resumer from 'resumer';
 import FormData from 'form-data';
+import {parse as parseURL} from 'url';
 import * as http from 'http';
 import * as fs from 'fs';
 
@@ -1375,6 +1376,17 @@ describe(`node-fetch with FOLLOW_SPEC = ${defaultFollowSpec}`, () => {
 	it('should support fetch with Request instance', function() {
 		url = `${base}hello`;
 		const req = new Request(url);
+		return fetch(req).then(res => {
+			expect(res.url).to.equal(url);
+			expect(res.ok).to.be.true;
+			expect(res.status).to.equal(200);
+		});
+	});
+
+	it('should support fetch with Node.js URL object', function() {
+		url = `${base}hello`;
+		const urlObj = parseURL(url);
+		const req = new Request(urlObj);
 		return fetch(req).then(res => {
 			expect(res.url).to.equal(url);
 			expect(res.ok).to.be.true;


### PR DESCRIPTION
Fixes #175. As a side effect, after this PR `new Request(null)` will not throw anymore, and therefore more conforming to the spec.