### PR TITLE
Add a new res.textConverted() and always use UTF-8 for res.text()

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -179,11 +179,6 @@ function convertBody(buffer, headers) {
 
 	// header
 	if (ct) {
-		// skip encoding detection altogether if not html/xml/plain text
-		if (!/text\/html|text\/plain|\+xml|\/xml/i.test(ct)) {
-			return buffer;
-		}
-
 		res = /charset=([^;]*)/i.exec(ct);
 	}
 

--- a/test/test.js
+++ b/test/test.js
@@ -915,11 +915,21 @@ describe('node-fetch', () => {
 		});
 	});
 
-	it('should support encoding decode, xml dtd detect', function() {
+	it('should only use UTF-8 decoding with text()', function() {
 		url = `${base}encoding/euc-jp`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
 			return res.text().then(result => {
+				expect(result).to.equal('<?xml version="1.0" encoding="EUC-JP"?><title>\ufffd\ufffd\ufffd\u0738\ufffd</title>');
+			});
+		});
+	});
+
+	it('should support encoding decode, xml dtd detect', function() {
+		url = `${base}encoding/euc-jp`;
+		return fetch(url).then(res => {
+			expect(res.status).to.equal(200);
+			return res.textConverted().then(result => {
 				expect(result).to.equal('<?xml version="1.0" encoding="EUC-JP"?><title>日本語</title>');
 			});
 		});
@@ -929,7 +939,7 @@ describe('node-fetch', () => {
 		url = `${base}encoding/shift-jis`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
-			return res.text().then(result => {
+			return res.textConverted().then(result => {
 				expect(result).to.equal('<div>日本語</div>');
 			});
 		});
@@ -939,7 +949,7 @@ describe('node-fetch', () => {
 		url = `${base}encoding/gbk`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
-			return res.text().then(result => {
+			return res.textConverted().then(result => {
 				expect(result).to.equal('<meta charset="gbk"><div>中文</div>');
 			});
 		});
@@ -949,7 +959,7 @@ describe('node-fetch', () => {
 		url = `${base}encoding/gb2312`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
-			return res.text().then(result => {
+			return res.textConverted().then(result => {
 				expect(result).to.equal('<meta http-equiv="Content-Type" content="text/html; charset=gb2312"><div>中文</div>');
 			});
 		});
@@ -960,7 +970,7 @@ describe('node-fetch', () => {
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
 			expect(res.headers.get('content-type')).to.be.null;
-			return res.text().then(result => {
+			return res.textConverted().then(result => {
 				expect(result).to.equal('中文');
 			});
 		});
@@ -970,7 +980,7 @@ describe('node-fetch', () => {
 		url = `${base}encoding/order1`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
-			return res.text().then(result => {
+			return res.textConverted().then(result => {
 				expect(result).to.equal('中文');
 			});
 		});
@@ -980,7 +990,7 @@ describe('node-fetch', () => {
 		url = `${base}encoding/order2`;
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
-			return res.text().then(result => {
+			return res.textConverted().then(result => {
 				expect(result).to.equal('中文');
 			});
 		});
@@ -991,7 +1001,7 @@ describe('node-fetch', () => {
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
 			const padding = 'a'.repeat(10);
-			return res.text().then(result => {
+			return res.textConverted().then(result => {
 				expect(result).to.equal(`${padding}<meta http-equiv="Content-Type" content="text/html; charset=Shift_JIS" /><div>日本語</div>`);
 			});
 		});
@@ -1002,7 +1012,7 @@ describe('node-fetch', () => {
 		return fetch(url).then(res => {
 			expect(res.status).to.equal(200);
 			const padding = 'a'.repeat(1200);
-			return res.text().then(result => {
+			return res.textConverted().then(result => {
 				expect(result).to.not.equal(`${padding}中文`);
 			});
 		});


### PR DESCRIPTION
Also uses iconv-lite directly instead of using the "encoding" package.

Fixes #184.