### PR TITLE
Support disabling the agent connection pooling. Fixes #196

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -48,7 +48,7 @@ function Request(input, init) {
 		init.compress : input.compress !== undefined ?
 		input.compress : true;
 	this.counter = init.counter || input.counter || 0;
-	this.agent = init.agent || input.agent;
+	this.agent = (init.agent === false ? false : (init.agent || input.agent));
 
 	Body.call(this, init.body || this._clone(input), {
 		timeout: init.timeout || input.timeout || 0,


### PR DESCRIPTION
This will allow you to provide `{agent: false}` as an option to disable Agent pooling per the node.js documentation.