### PR TITLE
Add support for blobs

### DIFF
--- a/src/blob.js
+++ b/src/blob.js
@@ -1,0 +1,104 @@
+// Based on https://github.com/tmpvar/jsdom/blob/aa85b2abf07766ff7bf5c1f6daafb3726f2f2db5/lib/jsdom/living/blob.js
+// (MIT licensed)
+
+export const BUFFER = Symbol('buffer');
+const TYPE = Symbol('type');
+const CLOSED = Symbol('closed');
+
+export default class Blob {
+	constructor() {
+		Object.defineProperty(this, Symbol.toStringTag, {
+			value: 'Blob',
+			writable: false,
+			enumerable: false,
+			configurable: true
+		});
+
+		this[CLOSED] = false;
+		this[TYPE] = '';
+
+		const blobParts = arguments[0];
+		const options = arguments[1];
+
+		const buffers = [];
+
+		if (blobParts) {
+			const a = blobParts;
+			const length = Number(a.length);
+			for (let i = 0; i < length; i++) {
+				const element = a[i];
+				let buffer;
+				if (element instanceof Buffer) {
+					buffer = element;
+				} else if (ArrayBuffer.isView(element)) {
+					buffer = new Buffer(new Uint8Array(element.buffer, element.byteOffset, element.byteLength));
+				} else if (element instanceof ArrayBuffer) {
+					buffer = new Buffer(new Uint8Array(element));
+				} else if (element instanceof Blob) {
+					buffer = element[BUFFER];
+				} else {
+					buffer = new Buffer(typeof element === 'string' ? element : String(element));
+				}
+				buffers.push(buffer);
+			}
+		}
+
+		this[BUFFER] = Buffer.concat(buffers);
+
+		let type = options && options.type !== undefined && String(options.type).toLowerCase();
+		if (type && !/[^\u0020-\u007E]/.test(type)) {
+			this[TYPE] = type;
+		}
+	}
+	get size() {
+		return this[CLOSED] ? 0 : this[BUFFER].length;
+	}
+	get type() {
+		return this[TYPE];
+	}
+	get isClosed() {
+		return this[CLOSED];
+	}
+	slice() {
+		const size = this.size;
+
+		const start = arguments[0];
+		const end = arguments[1];
+		let relativeStart, relativeEnd;
+		if (start === undefined) {
+			relativeStart = 0;
+		} else if (start < 0) {
+			relativeStart = Math.max(size + start, 0);
+		} else {
+			relativeStart = Math.min(start, size);
+		}
+		if (end === undefined) {
+			relativeEnd = size;
+		} else if (end < 0) {
+			relativeEnd = Math.max(size + end, 0);
+		} else {
+			relativeEnd = Math.min(end, size);
+		}
+		const span = Math.max(relativeEnd - relativeStart, 0);
+
+		const buffer = this[BUFFER];
+		const slicedBuffer = buffer.slice(
+			relativeStart,
+			relativeStart + span
+		);
+		const blob = new Blob([], { type: arguments[2] });
+		blob[BUFFER] = slicedBuffer;
+		blob[CLOSED] = this[CLOSED];
+		return blob;
+	}
+	close() {
+		this[CLOSED] = true;
+	}
+}
+
+Object.defineProperty(Blob.prototype, Symbol.toStringTag, {
+	value: 'BlobPrototype',
+	writable: false,
+	enumerable: false,
+	configurable: true
+});

--- a/test/test.js
+++ b/test/test.js
@@ -26,6 +26,7 @@ import Headers from '../src/headers.js';
 import Response from '../src/response.js';
 import Request from '../src/request.js';
 import Body from '../src/body.js';
+import Blob from '../src/blob.js';
 import FetchError from '../src/fetch-error.js';
 // test with native promise on node 0.11, and bluebird for node 0.10
 fetch.Promise = fetch.Promise || bluebird;
@@ -1419,6 +1420,20 @@ describe(`node-fetch with FOLLOW_SPEC = ${defaultFollowSpec}`, () => {
 		});
 	});
 
+	it('should support blob round-trip', function() {
+		url = `${base}hello`;
+
+		return fetch(url).then(res => res.blob()).then(blob => {
+			url = `${base}inspect`;
+			return fetch(url, {
+				method: 'POST',
+				body: blob
+			});
+		}).then(res => res.json()).then(({body}) => {
+			expect(body).to.equal('world');
+		});
+	});
+
 	it('should support wrapping Request instance', function() {
 		url = `${base}hello`;
 
@@ -1501,6 +1516,25 @@ describe(`node-fetch with FOLLOW_SPEC = ${defaultFollowSpec}`, () => {
 		const res = new Response('a=1');
 		return res.buffer().then(result => {
 			expect(result.toString()).to.equal('a=1');
+		});
+	});
+
+	it('should support blob() method in Request constructor', function() {
+		const res = new Response('a=1', {
+			headers: {
+				'Content-Type': 'text/plain'
+			}
+		});
+		return res.blob().then(function(result) {
+			expect(result).to.be.an.instanceOf(Blob);
+			expect(result.isClosed).to.be.false;
+			expect(result.size).to.equal(3);
+			expect(result.type).to.equal('text/plain');
+
+			result.close();
+			expect(result.isClosed).to.be.true;
+			expect(result.size).to.equal(0);
+			expect(result.type).to.equal('text/plain');
 		});
 	});
 
@@ -1621,6 +1655,28 @@ describe(`node-fetch with FOLLOW_SPEC = ${defaultFollowSpec}`, () => {
 		});
 	});
 
+	it('should support blob() method in Request constructor', function() {
+		url = base;
+		var req = new Request(url, {
+			body: 'a=1',
+			headers: {
+				'Content-Type': 'text/plain'
+			}
+		});
+		expect(req.url).to.equal(url);
+		return req.blob().then(function(result) {
+			expect(result).to.be.an.instanceOf(Blob);
+			expect(result.isClosed).to.be.false;
+			expect(result.size).to.equal(3);
+			expect(result.type).to.equal('text/plain');
+
+			result.close();
+			expect(result.isClosed).to.be.true;
+			expect(result.size).to.equal(0);
+			expect(result.type).to.equal('text/plain');
+		});
+	});
+
 	it('should support arbitrary url in Request constructor', function() {
 		url = 'anything';
 		const req = new Request(url);
@@ -1661,9 +1717,10 @@ describe(`node-fetch with FOLLOW_SPEC = ${defaultFollowSpec}`, () => {
 		});
 	});
 
-	it('should support arrayBuffer(), text(), json() and buffer() method in Body constructor', function() {
+	it('should support arrayBuffer(), blob(), text(), json() and buffer() method in Body constructor', function() {
 		const body = new Body('a=1');
 		expect(body).to.have.property('arrayBuffer');
+		expect(body).to.have.property('blob');
 		expect(body).to.have.property('text');
 		expect(body).to.have.property('json');
 		expect(body).to.have.property('buffer');


### PR DESCRIPTION
The `Blob` class isn't currently exposed as it is not really interoperable with any other library (the buffer is opaque from the user), and so far the only use cases for it in Node.js are for isomorphism with the browser. Eventually I might write a full implementation for the W3C File API in Node.js, so until then I don't want to encourage the use of it.

Fixes #78.