### PR TITLE
Refactor request options

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -254,5 +254,25 @@ export function clone(instance) {
 	return body;
 }
 
+/**
+ * Performs the operation "extract a `Content-Type` value from |object|" as
+ * specified in the specification:
+ * https://fetch.spec.whatwg.org/#concept-bodyinit-extract
+ *
+ * This function assumes that instance.body is present and non-null.
+ *
+ * @param   Mixed  instance  Response or Request instance
+ */
+export function extractContentType(instance) {
+	// detect form data input from form-data module
+	if (typeof instance.body.getBoundary === 'function') {
+		return `multipart/form-data;boundary=${instance.body.getBoundary()}`;
+	}
+
+	if (typeof instance.body === 'string') {
+		return 'text/plain;charset=UTF-8';
+	}
+}
+
 // expose Promise
 Body.Promise = global.Promise;

--- a/src/body.js
+++ b/src/body.js
@@ -274,5 +274,22 @@ export function extractContentType(instance) {
 	}
 }
 
+export function getTotalBytes(instance) {
+	const {body} = instance;
+
+	if (typeof body === 'string') {
+		return Buffer.byteLength(body);
+	} else if (body && typeof body.getLengthSync === 'function') {
+		// detect form data input from form-data module
+		if (body._lengthRetrievers && body._lengthRetrievers.length == 0 || // 1.x
+			body.hasKnownLength && body.hasKnownLength()) { // 2.x
+			return body.getLengthSync();
+		}
+	} else if (body === undefined || body === null) {
+		// this is only necessary for older nodejs releases (before iojs merge)
+		return 0;
+	}
+}
+
 // expose Promise
 Body.Promise = global.Promise;

--- a/src/index.js
+++ b/src/index.js
@@ -68,11 +68,6 @@ function fetch(url, opts) {
 			headers.set('accept', '*/*');
 		}
 
-		// detect form data input from form-data module, this hack avoid the need to pass multipart header manually
-		if (!headers.has('content-type') && options.body && typeof options.body.getBoundary === 'function') {
-			headers.set('content-type', `multipart/form-data; boundary=${options.body.getBoundary()}`);
-		}
-
 		// bring node-fetch closer to browser behavior by setting content-length automatically
 		if (!headers.has('content-length') && /post|put|patch|delete/i.test(options.method)) {
 			if (typeof options.body === 'string') {

--- a/src/request.js
+++ b/src/request.js
@@ -7,7 +7,7 @@
 
 import { format as format_url, parse as parse_url } from 'url';
 import Headers from './headers.js';
-import Body, { clone } from './body';
+import Body, { clone, extractContentType } from './body';
 
 /**
  * Request class
@@ -45,6 +45,13 @@ export default class Request extends Body {
 		this.method = init.method || input.method || 'GET';
 		this.redirect = init.redirect || input.redirect || 'follow';
 		this.headers = new Headers(init.headers || input.headers || {});
+
+		if (init.body) {
+			const contentType = extractContentType(this);
+			if (contentType && !this.headers.has('Content-Type')) {
+				this.headers.append('Content-Type', contentType);
+			}
+		}
 
 		// server only options
 		this.follow = init.follow !== undefined ?


### PR DESCRIPTION
Currently the Request objects used in a fetching process is hijacked to become the second parameter to [`http.request`](https://nodejs.org/api/http.html#http_http_request_options_callback) method, and code from distinct areas of the specification are interspersed in the giant `fetch()` function. This not only means that auditing with the spec in mind is difficult, the Request object contains multiple properties that are not technically in the specification (e.g. `protocol`, `path`, etc.), making isomorphic usage confusing.

This PR separates the Request object and the Node.js `http.request` options object, providing an internal function to convert the former to the latter. Also split are Content-Type and Content-Length extraction functions, which in the specification is grouped into the concept of Body.