### PR TITLE
Add cancel() method to streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,9 +177,7 @@ function Fetch(url, opts) {
 			// prepare response
 			var body = res.pipe(new stream.PassThrough());
 
-			body.cancel = function () {
-				res.destroy();
-			};
+			body.clientResponse = res;
 
 			var response_options = {
 				url: options.url

--- a/index.js
+++ b/index.js
@@ -176,6 +176,11 @@ function Fetch(url, opts) {
 
 			// prepare response
 			var body = res.pipe(new stream.PassThrough());
+
+			body.cancel = function () {
+				res.destroy();
+			};
+
 			var response_options = {
 				url: options.url
 				, status: res.statusCode


### PR DESCRIPTION
I'm unfortunately somewhat rusty in this regard, but I think this adds the possibility of canceling an infinite response as requested by me in #203 (and maybe as requested in #95).

This would add a `cancel()` that at least somewhat mimics the browser's `ReadableStream.cancel()`. To fully mimic it would probably have to [return a Promise](https://streams.spec.whatwg.org/#rs-cancel), but as there's no callback to the `message.destroy()` in node.js it would have to just be a `Promise.resolve()` then.

Thoughts on this approach? Good or bad?

Quickly looking at v2 it seems like this could be easily forward ported to that version.