### PR TITLE
Use ES2015 export syntax

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -16,11 +16,8 @@
       "presets": [
         [ "es2015", { "loose": true } ]
       ],
-      "ignore": [
-        "build"
-      ],
       "plugins": [
-        [ "istanbul", { "exclude": [ "src/blob.js", "test" ] } ],
+        [ "istanbul", { "exclude": [ "src/blob.js", "build", "test" ] } ],
 	"./build/babel-plugin"
       ]
     },

--- a/.babelrc
+++ b/.babelrc
@@ -6,19 +6,22 @@
     "test": {
       "presets": [
         [ "es2015", { "loose": true } ]
+      ],
+      "plugins": [
+        "transform-runtime",
+	"./build/babel-plugin"
       ]
     },
     "coverage": {
       "presets": [
         [ "es2015", { "loose": true } ]
       ],
+      "ignore": [
+        "build"
+      ],
       "plugins": [
-        [ "istanbul", {
-          "exclude": [
-            "src/blob.js",
-            "test"
-          ]
-        } ]
+        [ "istanbul", { "exclude": [ "src/blob.js", "test" ] } ],
+	"./build/babel-plugin"
       ]
     },
     "rollup": {

--- a/build/babel-plugin.js
+++ b/build/babel-plugin.js
@@ -1,0 +1,48 @@
+// This Babel plugin makes it possible to do CommonJS-style function exports
+
+const walked = Symbol('walked');
+
+module.exports = ({ types: t }) => ({
+  visitor: {
+    Program: {
+      exit(program) {
+        if (program[walked]) {
+          return;
+        }
+
+        for (let path of program.get('body')) {
+          if (path.isExpressionStatement()) {
+            const expr = path.get('expression');
+            if (expr.isAssignmentExpression() &&
+                expr.get('left').matchesPattern('exports.*')) {
+              const prop = expr.get('left').get('property');
+              if (prop.isIdentifier({ name: 'default' })) {
+                program.unshiftContainer('body', [
+                  t.expressionStatement(
+                    t.assignmentExpression('=',
+                      t.identifier('exports'),
+                      t.assignmentExpression('=',
+                        t.memberExpression(
+                          t.identifier('module'), t.identifier('exports')
+                        ),
+                        expr.node.right
+                      )
+                    )
+                  ),
+                  t.expressionStatement(
+                    t.assignmentExpression('=',
+                      expr.node.left, t.identifier('exports')
+                    )
+                  )
+                ]);
+                path.remove();
+              }
+            }
+          }
+        }
+
+        program[walked] = true;
+      }
+    }
+  }
+});

--- a/build/rollup-plugin.js
+++ b/build/rollup-plugin.js
@@ -1,0 +1,16 @@
+export default function tweakDefault() {
+  return {
+    transformBundle: function (source) {
+      var lines = source.split('\n');
+      for (var i = 0; i < lines.length; i++) {
+        var line = lines[i];
+        var matches = /^exports\['default'] = (.*);$/.exec(line);
+        if (matches) {
+          lines[i] = 'module.exports = exports = ' + matches[1] + ';';
+          break;
+        }
+      }
+      return lines.join('\n');
+    }
+  };
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lib/index.es.js"
   ],
   "scripts": {
-    "build": "rollup -c",
+    "build": "cross-env BABEL_ENV=rollup rollup -c",
     "prepublish": "npm run build",
     "test": "cross-env BABEL_ENV=test mocha --compilers js:babel-register test/test.js",
     "report": "cross-env BABEL_ENV=coverage nyc --reporter lcov --reporter text mocha -R spec test/test.js",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "codecov": "^1.0.1",
     "cross-env": "2.0.1",
     "form-data": ">=1.0.0",
+    "is-builtin-module": "^1.0.0",
     "mocha": "^3.1.2",
     "nyc": "^10.0.0",
     "parted": "^0.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import isBuiltin from 'is-builtin-module';
 import babel from 'rollup-plugin-babel';
 import resolve from 'rollup-plugin-node-resolve';
 
@@ -13,5 +14,12 @@ export default {
   targets: [
     { dest: 'lib/index.js', format: 'cjs' },
     { dest: 'lib/index.es.js', format: 'es' }
-  ]
+  ],
+  external: function (id) {
+    if (isBuiltin(id)) {
+      return true;
+    }
+    id = id.split('/').slice(0, id[0] === '@' ? 2 : 1).join('/');
+    return !!require('./package.json').dependencies[id];
+  }
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import isBuiltin from 'is-builtin-module';
 import babel from 'rollup-plugin-babel';
 import resolve from 'rollup-plugin-node-resolve';
+import tweakDefault from './build/rollup-plugin';
 
 process.env.BABEL_ENV = 'rollup';
 
@@ -9,7 +10,8 @@ export default {
   plugins: [
     babel({
       runtimeHelpers: true
-    })
+    }),
+    tweakDefault()
   ],
   targets: [
     { dest: 'lib/index.js', format: 'cjs' },

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ import FetchError from './fetch-error';
  * @param   Object   opts  Fetch options
  * @return  Promise
  */
-function fetch(url, opts) {
+export default function fetch(url, opts) {
 
 	// allow custom promise
 	if (!fetch.Promise) {
@@ -189,8 +189,6 @@ function fetch(url, opts) {
 
 };
 
-module.exports = fetch;
-
 /**
  * Redirect code matching
  *
@@ -210,6 +208,8 @@ fetch.Promise = global.Promise;
  * objects; existing objects are not affected.
  */
 fetch.FOLLOW_SPEC = false;
-fetch.Response = Response;
-fetch.Headers = Headers;
-fetch.Request = Request;
+export {
+	Headers,
+	Request,
+	Response
+};

--- a/test/test.js
+++ b/test/test.js
@@ -23,10 +23,14 @@ const expect = chai.expect;
 import TestServer from './server';
 
 // test subjects
-import fetch from '../src/index.js';
-import Headers from '../src/headers.js';
-import Response from '../src/response.js';
-import Request from '../src/request.js';
+import fetch, {
+	Headers,
+	Request,
+	Response
+} from '../src/';
+import HeadersOrig from '../src/headers.js';
+import RequestOrig from '../src/request.js';
+import ResponseOrig from '../src/response.js';
 import Body from '../src/body.js';
 import Blob from '../src/blob.js';
 import FetchError from '../src/fetch-error.js';
@@ -93,9 +97,9 @@ describe(`node-fetch with FOLLOW_SPEC = ${defaultFollowSpec}`, () => {
 	});
 
 	it('should expose Headers, Response and Request constructors', function() {
-		expect(fetch.Headers).to.equal(Headers);
-		expect(fetch.Response).to.equal(Response);
-		expect(fetch.Request).to.equal(Request);
+		expect(Headers).to.equal(HeadersOrig);
+		expect(Response).to.equal(ResponseOrig);
+		expect(Request).to.equal(RequestOrig);
 	});
 
 	(supportToString ? it : it.skip)('should support proper toString output for Headers, Response and Request objects', function() {


### PR DESCRIPTION
The following description is now irrelevant and incorrect.

----

This should be the last functional change before a 2.0.0-alpha.1 release. It makes it possible to use this module directly with [Rollup](http://rollupjs.org/), which we are already using to generate the output bundles.

The main concern can be that it requires more typing on the user's part. However, it is not always true:

Before:

```js
import fetch from 'node-fetch';

import fetch, { Headers, Response } from 'node-fetch';

const fetch = require('node-fetch');

const fetch = require('node-fetch');

const fetch = require('node-fetch');
const { Headers, Response } = fetch;

const fetch = require('node-fetch');
const Headers = fetch.Headers;
const Response = fetch.Response;
```

After:

```js
import { fetch } from 'node-fetch';

import { fetch, Headers, Response } from 'node-fetch';

const { fetch } = require('node-fetch');

const fetch = require('node-fetch').fetch;

const { fetch, Headers, Response } = require('node-fetch');

const fetch = require('node-fetch').fetch;
const Headers = require('node-fetch').Headers;
const Response = require('node-fetch').Response;
```