### PR TITLE
proper stack first line for FetchError instances

### DIFF
--- a/lib/fetch-error.js
+++ b/lib/fetch-error.js
@@ -16,10 +16,6 @@ module.exports = FetchError;
  * @return  FetchError
  */
 function FetchError(message, type, systemError) {
-
-	// hide custom error implementation details from end-users
-	Error.captureStackTrace(this, this.constructor);
-
 	this.name = this.constructor.name;
 	this.message = message;
 	this.type = type;
@@ -29,6 +25,8 @@ function FetchError(message, type, systemError) {
 		this.code = this.errno = systemError.code;
 	}
 
+	// hide custom error implementation details from end-users
+	Error.captureStackTrace(this, this.constructor);
 }
 
 require('util').inherits(FetchError, Error);

--- a/test/test.js
+++ b/test/test.js
@@ -1473,6 +1473,8 @@ describe('node-fetch', function() {
 		expect(err.type).to.equal('test-error');
 		expect(err.code).to.equal('ESOMEERROR');
 		expect(err.errno).to.equal('ESOMEERROR');
+
+		expect(new RegExp(err.name + ': ' + err.message).test(err.stack)).to.be.true;
 	});
 
 	it('should support https request', function() {


### PR DESCRIPTION
The `.stack` property gets cached in the `captureStackTrace()`
call, so whatever is set as the `name` and `message` at that time
will be used for the first line of the stack trace.

Before this patch, FetchError's stack would just say "Error"
as the first line. Now they correctly display the
"${name}: ${message}" of the error instances.

Test case included.