### PR TITLE
Url to string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "node"
 env:
   - FORMDATA_VERSION=1.0.0

--- a/lib/request.js
+++ b/lib/request.js
@@ -23,7 +23,7 @@ function Request(input, init) {
 
 	// normalize input
 	if (!(input instanceof Request)) {
-		url = input;
+		url = `${input}`;
 		url_parsed = parse_url(url);
 		input = {};
 	} else {

--- a/test/test.js
+++ b/test/test.js
@@ -46,6 +46,18 @@ describe('node-fetch', function() {
 		expect(p).to.have.property('then');
 	});
 
+	it('should return a promise when url instacnce of URL', function() { 
+		// same as url = new URL('https://github.com/'); 
+		url = { 
+			toString: function() { 
+				return 'https://github.com/'; 
+			} 
+		}; 
+		var p = fetch(url); 
+		expect(p).to.be.an.instanceof(fetch.Promise); 
+		expect(p).to.have.property('then'); 
+	});
+
 	it('should allow custom promise', function() {
 		url = 'http://example.com/';
 		var old = fetch.Promise;


### PR DESCRIPTION
[fetch method](https://fetch.spec.whatwg.org/#fetch-method) gets [RequestInfo](https://fetch.spec.whatwg.org/#requestinfo) parameter which can either be `Request` or be a `String`.
Using [URL](https://url.spec.whatwg.org/#URL-stringification-behavior) in that case is not possible. 
Because of `stringifier`, which
> indicates that objects that implement the interface **have a non-default conversion to a string**
> https://heycam.github.io/webidl/#idl-stringifiers

Hence, when param is not an instanceof `Request` it has to be converted to string.

Special thanks to @shvaikalesh

UPD:
> Using [URL](https://url.spec.whatwg.org/#URL-stringification-behavior) in that case is not possible. 

It's possible natively in browsers, but in scope of `node-fetch` it's not.