### PR TITLE
simplify request input convertation

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -24,15 +24,8 @@ export default class Request extends Body {
 
 		// normalize input
 		if (!(input instanceof Request)) {
-			if (input && input.href) {
-				// in order to support Node.js' Url objects; though WHATWG's URL objects
-				// will fall into this branch also (since their `toString()` will return
-				// `href` property anyway)
-				parsedURL = parse_url(input.href);
-			} else {
-				// coerce input to a string before attempting to parse
-				parsedURL = parse_url(input + '');
-			}
+			// in order to support either Node.js' Url objects or WHATWG's URL objects
+			parsedURL = parse_url(input.href || `${input}`);
 			input = {};
 		} else {
 			parsedURL = parse_url(input.url);


### PR DESCRIPTION
Continuing #216 
I've found out that [tests](https://github.com/bitinn/node-fetch/blob/v2/test/test.js#L1462-L1482) for Node.js Url and WHATWG's URL are present. 

But I propose to simplify input convertation regarding to `template literals` [specification](http://www.ecma-international.org/ecma-262/6.0/#sec-template-literals-runtime-semantics-evaluation)
> The string conversion semantics applied to the Expression value are like String.prototype.concat rather than the + operator.