### PR TITLE
Array Type-Checking

### DIFF
--- a/lib/headers.js
+++ b/lib/headers.js
@@ -7,6 +7,10 @@
 
 module.exports = Headers;
 
+var isArray = Array.isArray || function isArray(obj) {
+    return Object.prototype.toString.call(obj) == '[object Array]';
+};
+
 /**
  * Headers class
  *
@@ -35,7 +39,7 @@ function Headers(headers) {
 		} else if (typeof headers[prop] === 'number' && !isNaN(headers[prop])) {
 			this.set(prop, headers[prop].toString());
 
-		} else if (headers[prop] instanceof Array) {
+		} else if (isArray(headers[prop])) {
 			headers[prop].forEach(function(item) {
 				self.append(prop, item.toString());
 			});

--- a/lib/headers.js
+++ b/lib/headers.js
@@ -7,10 +7,6 @@
 
 module.exports = Headers;
 
-var isArray = Array.isArray || function isArray(obj) {
-    return Object.prototype.toString.call(obj) == '[object Array]';
-};
-
 /**
  * Headers class
  *
@@ -39,7 +35,7 @@ function Headers(headers) {
 		} else if (typeof headers[prop] === 'number' && !isNaN(headers[prop])) {
 			this.set(prop, headers[prop].toString());
 
-		} else if (isArray(headers[prop])) {
+		} else if (Array.isArray(headers[prop])) {
 			headers[prop].forEach(function(item) {
 				self.append(prop, item.toString());
 			});


### PR DESCRIPTION
In migrating an HTTP test suite that uses `node-fetch` from Mocha to Jest, a number of tests starting failing when trying to make assertions on cookies. When I dug into it, I traced it back to this Array type check in `Headers`.

Basically, because [Jest executes tests in a vm](https://github.com/facebook/jest/issues/2048), the class instances of core types like `Array` are different from those within Node's libraries like `http`, so `instanceof` checks against them fail.

The [recommended approach](http://stackoverflow.com/questions/22289727/difference-between-using-array-isarray-and-instanceof-array) for checking if an object is an array is to instead use the `Array.isArray` function.

This PR also includes a fallback for old versions of Node that don't include `Array.isArray` for maximum backwards compatibility.