### PR TITLE
Add a `fetch` option to allow wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,8 @@ The default values are shown after each option key.
 	timeout: 0,         // req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies)
 	compress: true,     // support gzip/deflate content encoding. false to disable
 	size: 0,            // maximum response body size in bytes. 0 to disable
-	agent: null         // http(s).Agent instance, allows custom proxy, certificate etc.
+	agent: null,        // http(s).Agent instance, allows custom proxy, certificate etc.
+	resolver: null      // fetch-compatible function to use when following redirects (to support wrappers)
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,10 @@ export default function fetch(url, opts) {
 
 				request.counter++;
 
-				resolve(fetch(resolve_url(request.url, res.headers.location), request));
+				// allow to pass a fetch-compatible function for supporting wrappers
+				const resolver = opts && opts.resolver || fetch;
+
+				resolve(resolver(resolve_url(request.url, res.headers.location), request));
 				return;
 			}
 

--- a/test/test.js
+++ b/test/test.js
@@ -396,6 +396,19 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should allow redirect resolver', function() {
+		url = `${base}redirect/301`;
+		opts = {
+			resolver: (url, opts) => fetch(url, opts).then(res => {
+				res.customResolver = true;
+				return res;
+			})
+		};
+		return fetch(url, opts).then(res => {
+			expect(res.customResolver).to.be.true;
+		});
+	});
+
 	it('should handle client-error response', function() {
 		url = `${base}error/400`;
 		return fetch(url).then(res => {


### PR DESCRIPTION
This way a wrapper library like [fetch-cookie] could transparently leverage node-fetch way of handling redirects without having to force `{ redirect: 'manual' }` and re-implement the logic.

[fetch-cookie]: https://github.com/valeriangalliat/fetch-cookie

Instead, a wrapper could just pass the `fetch` option and point it to the wrapped function. And this would also allow wrappers to be combined as long as they also support being given the `fetch` option, e.g.:

```js
function fetchCookie(url, opts) {
    return fetch(url, Object.assign({ fetch: fetchCookie }, opts));
}
```