### PR TITLE
feat(http.Agent): allow passing agent option as an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Note that only `method`, `headers`, `redirect` and `body` are allowed in `window
 	, compress: true     // support gzip/deflate content encoding. false to disable
 	, size: 0            // maximum response body size in bytes. 0 to disable
 	, body: empty        // request body. can be a string, buffer, readable stream
-	, agent: null        // http.Agent instance, allows custom proxy, certificate etc.
+	, agent: null        // http.Agent instance or options object, allows custom proxy, certificate etc.
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -39,12 +39,17 @@ export default function fetch(url, opts) {
 		const request = new Request(url, opts);
 
 		const options = getNodeRequestOptions(request);
+		const protocol = options.protocol === 'https:' ? https : http;
+
+		if (options.agent && typeof options.agent === 'object' && !(options.agent instanceof http.Agent)) {
+			options.agent = new protocol.Agent(options.agent)
+		}
 
 		if (!options.protocol || !options.hostname) {
 			throw new Error('only absolute urls are supported');
 		}
 
-		const send = (options.protocol === 'https:' ? https : http).request;
+		const send = protocol.request;
 
 		// http.request only support string as host header, this hack make custom host header possible
 		if (options.headers.host) {

--- a/test/test.js
+++ b/test/test.js
@@ -1319,6 +1319,20 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should create http.Agent class if options.agent is provided as an object', function() {
+		url = `${base}inspect`;
+		opts = {
+			agent: {
+				keepAlive: true
+			}
+		};
+		return fetch(url, opts).then(res => {
+			return res.json();
+		}).then(res => {
+			expect(res.headers['connection']).to.equal('keep-alive');
+		});
+	});
+
 	it('should ignore unsupported attributes while reading headers', function() {
 		const FakeHeader = function () {};
 		// prototypes are currently ignored


### PR DESCRIPTION
allows for controlling `http.Agent` without manually creating a new external object, this is useful

to prevent "requiring" `http`/`https` in SPA and isomorphic apps

Fixes #15