### PR TITLE
Decompress slightly invalid gzip response

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -71,6 +71,16 @@ export default class TestServer {
 			});
 		}
 
+		if (p === '/truncated-gzip') {
+			res.statusCode = 200;
+			res.setHeader('Content-Type', 'text/plain');
+			res.setHeader('Content-Encoding', 'gzip');
+			zlib.gzip('hello world', function(err, buffer) {
+				// truncate the CRC checksum and size check at the end of the stream
+				res.end(buffer.slice(0, buffer.length - 8));
+			});
+		}
+
 		if (p === '/deflate') {
 			res.statusCode = 200;
 			res.setHeader('Content-Type', 'text/plain');

--- a/test/test.js
+++ b/test/test.js
@@ -520,6 +520,17 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should decompress slightly invalid gzip response', function() {
+		url = `${base}truncated-gzip`;
+		return fetch(url).then(res => {
+			expect(res.headers.get('content-type')).to.equal('text/plain');
+			return res.text().then(result => {
+				expect(result).to.be.a('string');
+				expect(result).to.equal('hello world');
+			});
+		});
+	});
+
 	it('should decompress deflate response', function() {
 		url = `${base}deflate`;
 		return fetch(url).then(res => {


### PR DESCRIPTION
Prevents following error when compressed response is slightly invalid/truncated (it happens rarely, but still)
```
Error: unexpected end of file
  File "zlib.js", line 370, col 17, in Zlib._handle.onerror
```