### PR TITLE
transpilling to Node 4 instead of dropped 0.x

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,7 @@
   "env": {
     "test": {
       "presets": [
-        [ "env", { "loose": true, "targets": { "node": 0.12 } } ]
+        [ "env", { "loose": true, "targets": { "node": 4 } } ]
       ],
       "plugins": [
         "transform-runtime",
@@ -14,7 +14,7 @@
     },
     "coverage": {
       "presets": [
-        [ "env", { "loose": true, "targets": { "node": 0.12 } } ]
+        [ "env", { "loose": true, "targets": { "node": 4 } } ]
       ],
       "plugins": [
         [ "istanbul", { "exclude": [ "src/blob.js", "build", "test" ] } ],
@@ -23,7 +23,7 @@
     },
     "rollup": {
       "presets": [
-        [ "env", { "loose": true, "targets": { "node": 0.12 }, "modules": false } ]
+        [ "env", { "loose": true, "targets": { "node": 4 }, "modules": false } ]
       ]
     }
   }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "6"
   - "node"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "lib/index.js",
     "lib/index.es.js"
   ],
+  "engines": {
+    "node": ">=4"
+  },
   "scripts": {
     "build": "cross-env BABEL_ENV=rollup rollup -c",
     "prepublish": "npm run build",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "babel-plugin-istanbul": "^3.0.0",
     "babel-plugin-transform-runtime": "^6.15.0",
-    "babel-preset-env": "^1.1.8",
+    "babel-preset-env": "^1.1.10",
     "babel-register": "^6.16.3",
     "bluebird": "^3.3.4",
     "chai": "^3.5.0",

--- a/src/headers.js
+++ b/src/headers.js
@@ -5,7 +5,7 @@
  * Headers class offers convenient helpers
  */
 
-import { checkIsHttpToken, checkInvalidHeaderChar } from './common.js';
+import { checkInvalidHeaderChar, checkIsHttpToken } from './common.js';
 
 function sanitizeName(name) {
 	name += '';
@@ -270,13 +270,6 @@ const HeadersIteratorPrototype = Object.setPrototypeOf({
 }, Object.getPrototypeOf(
 	Object.getPrototypeOf([][Symbol.iterator]())
 ));
-
-// On Node.js v0.12 the %IteratorPrototype% object is broken
-if (typeof HeadersIteratorPrototype[Symbol.iterator] !== 'function') {
-	HeadersIteratorPrototype[Symbol.iterator] = function () {
-		return this;
-	};
-}
 
 Object.defineProperty(HeadersIteratorPrototype, Symbol.toStringTag, {
 	value: 'HeadersIterator',


### PR DESCRIPTION
Your docs says that `2.x` dropping support for `node 0.x` while Babel transpilling still targets that version. This PR fixes that as well as dropping `0.x` from travis, updates `babel-preset-env` to latest version and adding appropriate `engines` to `package.json`