### PR TITLE
remove is-stream and buffer-to-arraybuffer in favor of native methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "babel-runtime": "^6.11.6",
-    "buffer-to-arraybuffer": "0.0.4",
     "encoding": "^0.1.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   "dependencies": {
     "babel-runtime": "^6.11.6",
     "buffer-to-arraybuffer": "0.0.4",
-    "encoding": "^0.1.11",
-    "is-stream": "^1.0.1"
+    "encoding": "^0.1.11"
   }
 }

--- a/src/body.js
+++ b/src/body.js
@@ -6,9 +6,8 @@
  */
 
 import {convert} from 'encoding';
-import bodyStream from 'is-stream';
 import toArrayBuffer from 'buffer-to-arraybuffer';
-import {PassThrough} from 'stream';
+import Stream, {PassThrough} from 'stream';
 import Blob, {BUFFER} from './blob.js';
 import FetchError from './fetch-error.js';
 
@@ -36,7 +35,7 @@ export default function Body(body, {
 		// body is blob
 	} else if (Buffer.isBuffer(body)) {
 		// body is buffer
-	} else if (bodyStream(body)) {
+	} else if (body instanceof Stream) {
 		// body is stream
 	} else {
 		// none of the above
@@ -154,7 +153,7 @@ function consumeBody(body) {
 	}
 
 	// istanbul ignore if: should never happen
-	if (!bodyStream(this.body)) {
+	if (!(this.body instanceof Stream)) {
 		return Body.Promise.resolve(new Buffer(0));
 	}
 
@@ -282,7 +281,7 @@ export function clone(instance) {
 
 	// check that body is a stream and not form-data object
 	// note: we can't clone the form-data object without having it as a dependency
-	if (bodyStream(body) && typeof body.getBoundary !== 'function') {
+	if ((body instanceof Stream) && (typeof body.getBoundary !== 'function')) {
 		// tee instance body
 		p1 = new PassThrough();
 		p2 = new PassThrough();

--- a/src/body.js
+++ b/src/body.js
@@ -6,7 +6,6 @@
  */
 
 import {convert} from 'encoding';
-import toArrayBuffer from 'buffer-to-arraybuffer';
 import Stream, {PassThrough} from 'stream';
 import Blob, {BUFFER} from './blob.js';
 import FetchError from './fetch-error.js';
@@ -59,7 +58,7 @@ Body.prototype = {
 	 * @return  Promise
 	 */
 	arrayBuffer() {
-		return consumeBody.call(this).then(buf => toArrayBuffer(buf));
+		return consumeBody.call(this).then(buf => buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength));
 	},
 
 	/**


### PR DESCRIPTION
Same method of `Stream` detection is used at `koa` sources, so, I believe it's pretty bulletproof.
And since `node 4.x` is minimum supported version now, we can also drop `buffer-to-arraybuffer` and use `slice` directly for converting to `ArrayBuffer`