### PR TITLE
fix: do not re-initialize Headers (fixes #251)

### DIFF
--- a/src/headers.js
+++ b/src/headers.js
@@ -34,6 +34,16 @@ export default class Headers {
 	constructor(init = undefined) {
 		this[MAP] = Object.create(null);
 
+		if (init instanceof Headers) {
+			for (const [key, values] of Object.entries(init.raw())) {
+				for (const value of values) {
+					this.append(key, value);
+				}
+			}
+
+			return;
+		}
+
 		// We don't worry about converting prop to ByteString here as append()
 		// will handle it.
 		if (init == null) {

--- a/src/headers.js
+++ b/src/headers.js
@@ -35,9 +35,12 @@ export default class Headers {
 		this[MAP] = Object.create(null);
 
 		if (init instanceof Headers) {
-			for (const [key, values] of Object.entries(init.raw())) {
-				for (const value of values) {
-					this.append(key, value);
+			const rawHeaders = init.raw();
+			const headerNames = Object.keys(rawHeaders);
+
+			for (const headerName of headerNames) {
+				for (const value of rawHeaders[headerName]) {
+					this.append(headerName, value);
 				}
 			}
 

--- a/src/response.js
+++ b/src/response.js
@@ -23,7 +23,12 @@ export default class Response {
 		this.url = opts.url;
 		this.status = opts.status || 200;
 		this.statusText = opts.statusText || STATUS_CODES[this.status];
-		this.headers = new Headers(opts.headers);
+
+		if (opts.headers instanceof Headers) {
+			this.headers = opts.headers;
+		} else {
+			this.headers = new Headers(opts.headers);
+		}
 
 		Object.defineProperty(this, Symbol.toStringTag, {
 			value: 'Response',

--- a/src/response.js
+++ b/src/response.js
@@ -24,11 +24,7 @@ export default class Response {
 		this.status = opts.status || 200;
 		this.statusText = opts.statusText || STATUS_CODES[this.status];
 
-		if (opts.headers instanceof Headers) {
-			this.headers = opts.headers;
-		} else {
-			this.headers = new Headers(opts.headers);
-		}
+		this.headers = new Headers(opts.headers);
 
 		Object.defineProperty(this, Symbol.toStringTag, {
 			value: 'Response',

--- a/test/test.js
+++ b/test/test.js
@@ -1205,6 +1205,18 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should return all headers using raw()', function() {
+		url = `${base}cookie`;
+		return fetch(url).then(res => {
+			const expected = [
+				'a=1',
+				'b=1'
+			];
+
+			expect(res.headers.raw()['set-cookie']).to.deep.equal(expected);
+		});
+	});
+
 	it('should allow iterating through all headers with forEach', function() {
 		const headers = new Headers([
 			['b', '2'],


### PR DESCRIPTION
Without this change the headers get flattened in [`/src/headers.js#L42-L70`](https://github.com/bitinn/node-fetch/blob/a1e76b97e18f28395bdb46e3a849800f52ee8027/src/headers.js#L42-L70). This is a result of an iterator [`/src/headers.js#L197-L199`](https://github.com/bitinn/node-fetch/blob/a1e76b97e18f28395bdb46e3a849800f52ee8027/src/headers.js#L197-L199) using getter [`/src/headers.js#L89-L96`](https://github.com/bitinn/node-fetch/blob/a1e76b97e18f28395bdb46e3a849800f52ee8027/src/headers.js#L89-L96) that joins multiple header values into a comma separated list.