### PR TITLE
Revert "Allow passing agent option as an object (#236)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The default values are shown after each option key.
 	timeout: 0,         // req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies)
 	compress: true,     // support gzip/deflate content encoding. false to disable
 	size: 0,            // maximum response body size in bytes. 0 to disable
-	agent: null         // http(s).Agent instance or options object, allows custom proxy, certificate etc.
+	agent: null         // http(s).Agent instance, allows custom proxy, certificate etc.
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -39,14 +39,7 @@ export default function fetch(url, opts) {
 		const request = new Request(url, opts);
 		const options = getNodeRequestOptions(request);
 
-		const protocol = options.protocol === 'https:' ? https : http;
-		const { agent } = options;
-
-		if (agent && typeof agent === 'object' && !(agent instanceof http.Agent)) {
-			options.agent = new protocol.Agent(agent);
-		}
-
-		const send = protocol.request;
+		const send = (options.protocol === 'https:' ? https : http).request;
 
 		// http.request only support string as host header, this hack make custom host header possible
 		if (options.headers.host) {

--- a/src/request.js
+++ b/src/request.js
@@ -159,8 +159,6 @@ export function getNodeRequestOptions(request) {
 	// HTTP-network fetch step 4
 	// chunked encoding is handled by Node.js
 
-	// Agent normalization is done in fetch().
-
 	return Object.assign({}, parsedURL, {
 		method: request.method,
 		headers: headers.raw(),

--- a/test/test.js
+++ b/test/test.js
@@ -1335,18 +1335,6 @@ describe('node-fetch', () => {
 		});
 	});
 
-	it('should create http.Agent class if options.agent is provided as an object', function() {
-		url = `${base}inspect`;
-		opts = {
-			agent: {
-				keepAlive: true
-			}
-		};
-		return fetch(url, opts).then(res => res.json()).then(res => {
-			expect(res.headers['connection']).to.equal('keep-alive');
-		});
-	});
-
 	it('should ignore unsupported attributes while reading headers', function() {
 		const FakeHeader = function () {};
 		// prototypes are currently ignored


### PR DESCRIPTION
This reverts commit ec29e3d2640586bc07cddf894e2aa10461b20ec0.

This patch prevents any agent being passed in which is not explicitly an instance of `http.Agent`. This makes `node-fetch` no longer compatible with https://npm.im/proxy-agent, which is one example of a library that does not directly inherit from `http.Agent` directly.

Sorry for the revert -- I don't have an alternative patch because I don't believe this is something node-fetch should be doing automatically, because of how much of a limitation this could impose.

The original PR stated that this was to prevent requiring http/https, and the effect would effectively be to force creation of an Agent on every call. Note that this is already the behavior specified for 
http.Agent when http.request received `false`. (See the bottom of the [section on http.Agent in the Node docs](https://nodejs.org/dist/latest-v7.x/docs/api/http.html#http_class_http_agent).

Cheers, and with apologies to @ahmadnassri for reverting their PR.