### PR TITLE
use browser natives when bundled for the browser

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,4 @@
+module.exports = exports = window.fetch;
+exports.Headers = window.Headers;
+exports.Request = window.Request;
+exports.Response = window.Response;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0-alpha.3",
   "description": "A light-weight module that brings window.fetch to node.js",
   "main": "lib/index.js",
+  "browser": "./browser",
   "module": "lib/index.es.js",
   "files": [
     "lib/index.js",


### PR DESCRIPTION
This makes `node-fetch` reference the browser native fetch API when bundled for the browser.

https://github.com/bitinn/node-fetch/issues/262