### PR TITLE
expose url property on request object

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -79,16 +79,14 @@ export default class Request {
 		this.agent = init.agent || input.agent;
 
 		this[PARSED_URL] = parsedURL;
+		this.url = format_url(parsedURL);
+
 		Object.defineProperty(this, Symbol.toStringTag, {
 			value: 'Request',
 			writable: false,
 			enumerable: false,
 			configurable: true
 		});
-	}
-
-	get url() {
-		return format_url(this[PARSED_URL]);
 	}
 
 	/**

--- a/test/test.js
+++ b/test/test.js
@@ -973,6 +973,17 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should expose url property on request object', function() {
+		const request = new Request(`${base}/foo`);
+		let found = false;
+		for (const k in request) {
+				if (k === 'url') {
+				found = true;
+			}
+		}
+		expect(found).to.be.true;
+	});
+
 	it('should reject decoding body twice', function() {
 		url = `${base}plain`;
 		return fetch(url).then(res => {


### PR DESCRIPTION
In browsers, the `url` property appears when iterating over the properties of an instance of Request. I think that is the proper behavior. `node-fetch` is currently accessing `url` with a getter, so it is hidden when iterating the properties or logging the object. I removed the getter, set `this.url` in the constructor, and added a test that `url` is exposed. All the tests continue to pass after my change with no additional changes needed. I'm unsure why it was a getter, as no tests depended on it being so.