### PR TITLE
1.x branch: fix test server for node 8 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ node_modules
 .nyc_output
 lib/index.js
 lib/index.es.js
+package-lock.json

--- a/test/server.js
+++ b/test/server.js
@@ -12,6 +12,9 @@ function TestServer() {
 	this.server = http.createServer(this.router);
 	this.port = 30001;
 	this.hostname = 'localhost';
+	// node 8 default keepalive timeout is 5000ms
+	// make it shorter here as we want to close server quickly at the end of tests
+	this.server.keepAliveTimeout = 1000;
 	this.server.on('error', function(err) {
 		console.log(err.stack);
 	});


### PR DESCRIPTION
Node 8 http server now supports Keep-Alive connection pooling, one of the tests use keep-alive agent which causes `server.close()` to timeout mocha.

I will submit a PR for 2.x branch when available...