### PR TITLE
Adds arrayBuffer method

### DIFF
--- a/lib/body.js
+++ b/lib/body.js
@@ -76,6 +76,19 @@ Body.prototype.buffer = function() {
 };
 
 /**
+ * Decode response as arrayBuffer
+ *
+ * @return  Promise
+ */
+Body.prototype.arrayBuffer = function() {
+
+  return this._decode().then(function(buf){
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  });
+
+},
+
+/**
  * Decode buffers into utf-8 string
  *
  * @return  Promise


### PR DESCRIPTION
I noticed that `arrayBuffer`was missing from body in 1.x.
I think #210 talked about this as well so I thought I contribute back :)
Let me know what you think.