### PR TITLE
refactor deprecated `new Buffer` with Buffer.from and Buffer.alloc

### DIFF
--- a/src/blob.js
+++ b/src/blob.js
@@ -31,9 +31,9 @@ export default class Blob {
 				if (element instanceof Buffer) {
 					buffer = element;
 				} else if (ArrayBuffer.isView(element)) {
-					buffer = Buffer.from(new Uint8Array(element.buffer, element.byteOffset, element.byteLength));
+					buffer = Buffer.from(element.buffer, element.byteOffset, element.byteLength);
 				} else if (element instanceof ArrayBuffer) {
-					buffer = Buffer.from(new Uint8Array(element));
+					buffer = Buffer.from(element);
 				} else if (element instanceof Blob) {
 					buffer = element[BUFFER];
 				} else {

--- a/src/blob.js
+++ b/src/blob.js
@@ -31,13 +31,13 @@ export default class Blob {
 				if (element instanceof Buffer) {
 					buffer = element;
 				} else if (ArrayBuffer.isView(element)) {
-					buffer = new Buffer(new Uint8Array(element.buffer, element.byteOffset, element.byteLength));
+					buffer = Buffer.from(new Uint8Array(element.buffer, element.byteOffset, element.byteLength));
 				} else if (element instanceof ArrayBuffer) {
-					buffer = new Buffer(new Uint8Array(element));
+					buffer = Buffer.from(new Uint8Array(element));
 				} else if (element instanceof Blob) {
 					buffer = element[BUFFER];
 				} else {
-					buffer = new Buffer(typeof element === 'string' ? element : String(element));
+					buffer = Buffer.from(typeof element === 'string' ? element : String(element));
 				}
 				buffers.push(buffer);
 			}

--- a/src/body.js
+++ b/src/body.js
@@ -145,12 +145,12 @@ function consumeBody(body) {
 
 	// body is null
 	if (this.body === null) {
-		return Body.Promise.resolve(new Buffer(0));
+		return Body.Promise.resolve(Buffer.alloc(0));
 	}
 
 	// body is string
 	if (typeof this.body === 'string') {
-		return Body.Promise.resolve(new Buffer(this.body));
+		return Body.Promise.resolve(Buffer.from(this.body));
 	}
 
 	// body is blob
@@ -165,7 +165,7 @@ function consumeBody(body) {
 
 	// istanbul ignore if: should never happen
 	if (!(this.body instanceof Stream)) {
-		return Body.Promise.resolve(new Buffer(0));
+		return Body.Promise.resolve(Buffer.alloc(0));
 	}
 
 	// body is stream

--- a/test/test.js
+++ b/test/test.js
@@ -706,7 +706,7 @@ describe('node-fetch', () => {
 		url = `${base}inspect`;
 		opts = {
 			method: 'POST'
-			, body: new Buffer('a=1', 'utf-8')
+			, body: Buffer.from('a=1', 'utf-8')
 		};
 		return fetch(url, opts).then(res => {
 			return res.json();
@@ -1418,7 +1418,7 @@ describe('node-fetch', () => {
 		res.j = NaN;
 		res.k = true;
 		res.l = false;
-		res.m = new Buffer('test');
+		res.m = Buffer.from('test');
 
 		const h1 = new Headers(res);
 		h1.set('n', [1, 2]);
@@ -1714,7 +1714,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should support buffer as body in Response constructor', function() {
-		const res = new Response(new Buffer('a=1'));
+		const res = new Response(Buffer.from('a=1'));
 		return res.text().then(result => {
 			expect(result).to.equal('a=1');
 		});
@@ -1810,7 +1810,7 @@ describe('node-fetch', () => {
 		url = base;
 		var req = new Request(url, {
 			method: 'POST',
-			body: new Buffer('a=1')
+			body: Buffer.from('a=1')
 		});
 		expect(req.url).to.equal(url);
 		return req.blob().then(function(result) {


### PR DESCRIPTION
Just need a sanity check:
blob.js line 34... Buffer.from(ArrayBuffer) or Buffer.from(ArrayBuffer#buffer) ?