### PR TITLE
Fix cannot receive http header array issue.

### DIFF
--- a/lib/headers.js
+++ b/lib/headers.js
@@ -35,7 +35,7 @@ function Headers(headers) {
 		} else if (typeof headers[prop] === 'number' && !isNaN(headers[prop])) {
 			this.set(prop, headers[prop].toString());
 
-		} else if (headers[prop] instanceof Array) {
+		} else if (Array.isArray(headers[prop])) {
 			headers[prop].forEach(function(item) {
 				self.append(prop, item.toString());
 			});


### PR DESCRIPTION
On [jest](https://www.npmjs.com/package/jest) test framework, cannot receive http header array.

Test project
https://github.com/H1Gdev/test_set_cookie

1. npm install
2. npm test

**Expect**
-> receive 'set-cookie' header.
**Actual**
-> cannot receive 'set-cookie' header.