### PR TITLE
proper stack first line for FetchError instances (#215)

### DIFF
--- a/lib/fetch-error.js
+++ b/lib/fetch-error.js
@@ -17,9 +17,6 @@ module.exports = FetchError;
  */
 function FetchError(message, type, systemError) {
 
-	// hide custom error implementation details from end-users
-	Error.captureStackTrace(this, this.constructor);
-
 	this.name = this.constructor.name;
 	this.message = message;
 	this.type = type;
@@ -29,6 +26,8 @@ function FetchError(message, type, systemError) {
 		this.code = this.errno = systemError.code;
 	}
 
+	// hide custom error implementation details from end-users
+	Error.captureStackTrace(this, this.constructor);
 }
 
 require('util').inherits(FetchError, Error);

--- a/test/test.js
+++ b/test/test.js
@@ -1470,8 +1470,8 @@ describe('node-fetch', function() {
 		expect(err.type).to.equal('test-error');
 		expect(err.code).to.equal('ESOMEERROR');
 		expect(err.errno).to.equal('ESOMEERROR');
-		expect(err.stack).to.include('funcName')
-			.and.to.startWith(`${err.name}: ${err.message}`);
+		expect(err.stack).to.include('funcName');
+		expect(err.stack.split('\n')[0]).to.equal(err.name + ': ' + err.message);
 	});
 
 	it('should support https request', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -1458,7 +1458,7 @@ describe('node-fetch', function() {
 		expect(body).to.have.property('buffer');
 	});
 
-	it('should create custom FetchError', function() {
+	it('should create custom FetchError', function funcName() {
 		var systemError = new Error('system');
 		systemError.code = 'ESOMEERROR';
 
@@ -1470,6 +1470,8 @@ describe('node-fetch', function() {
 		expect(err.type).to.equal('test-error');
 		expect(err.code).to.equal('ESOMEERROR');
 		expect(err.errno).to.equal('ESOMEERROR');
+		expect(err.stack).to.include('funcName')
+			.and.to.startWith(`${err.name}: ${err.message}`);
 	});
 
 	it('should support https request', function() {


### PR DESCRIPTION
The `.stack` property gets cached in the `captureStackTrace()` call, so
whatever is set as the `name` and `message` at that time will be used
for the first line of the stack trace.

Before this patch, FetchError's stack would just say "Error" as the
first line. Now they correctly display the "${name}: ${message}" of the
error instances.

Test case included.

Signed-off-by: Timothy Gu <timothygu99@gmail.com>