### PR TITLE
add browser.js to npm published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "module": "lib/index.es.js",
   "files": [
     "lib/index.js",
-    "lib/index.es.js"
+    "lib/index.es.js",
+    "browser.js"
   ],
   "engines": {
     "node": "4.x || >=6.0.0"


### PR DESCRIPTION
`browser.js` isn't in the npm package, so it doesn't work in browsers. This should fix it.