### PR TITLE
Add an "additionalRequestProperties" option to requests

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -79,6 +79,10 @@ export default class Request {
 		this.counter = init.counter || input.counter || 0;
 		this.agent = init.agent || input.agent;
 
+		if (init.additionalRequestProperties) {
+			Object.assign(this, init.additionalRequestProperties);
+		}
+
 		this[PARSED_URL] = parsedURL;
 		Object.defineProperty(this, Symbol.toStringTag, {
 			value: 'Request',


### PR DESCRIPTION
This is to allow eg. AWS XRay instrumentation, which requires the addition of an "XRaySegment" value to be sent to the `http.request()` call.

The reasoning for adding `additionalRequestProperties` is to preserve backwards compatibility – just assigning all unknown properties from `init` could result in unwanted values being forwarded to `http.request()`.

I am aware that this module wants to mimik the browser `fetch()` and this property doesn't align with that, but it do align with properties like `agent` and is useful when eg. there's a need to better trace calls across microservices in a server environment.