### PR TITLE
fix iterating through Headers#entries()

### DIFF
--- a/src/headers.js
+++ b/src/headers.js
@@ -238,6 +238,7 @@ function createHeadersIterator(target, kind) {
 		kind,
 		index: 0
 	};
+    iterator[Symbol.iterator] = () => iterator;
 	return iterator;
 }
 

--- a/src/headers.js
+++ b/src/headers.js
@@ -238,7 +238,6 @@ function createHeadersIterator(target, kind) {
 		kind,
 		index: 0
 	};
-	iterator[Symbol.iterator] = () => iterator;
 	return iterator;
 }
 
@@ -281,9 +280,7 @@ const HeadersIteratorPrototype = Object.setPrototypeOf({
 			done: false
 		};
 	}
-}, Object.getPrototypeOf(
-	Object.getPrototypeOf([][Symbol.iterator]())
-));
+}, Object.getPrototypeOf([][Symbol.iterator]()));
 
 Object.defineProperty(HeadersIteratorPrototype, Symbol.toStringTag, {
 	value: 'HeadersIterator',

--- a/src/headers.js
+++ b/src/headers.js
@@ -238,7 +238,7 @@ function createHeadersIterator(target, kind) {
 		kind,
 		index: 0
 	};
-    iterator[Symbol.iterator] = () => iterator;
+	iterator[Symbol.iterator] = () => iterator;
 	return iterator;
 }
 


### PR DESCRIPTION
fixes cases like
```js
for (const [name, value] of response.headers.entries()) {
  ...
}
```