### PR TITLE
Request and Response should define read only attributes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,18 +84,22 @@ export default function fetch(url, opts) {
 					return;
 				}
 
+				let opts = {
+					headers: new Headers(request.headers),
+					follow: request.follow,
+					counter: request.counter + 1,
+					agent: request.agent,
+					compress: request.compress,
+				};
 				// per fetch spec, for POST request with 301/302 response, or any request with 303 response, use GET when following redirect
 				if (res.statusCode === 303
 					|| ((res.statusCode === 301 || res.statusCode === 302) && request.method === 'POST'))
 				{
-					request.method = 'GET';
-					request.body = null;
-					request.headers.delete('content-length');
+					opts.method = 'GET';
+					opts.headers.delete('content-length');
 				}
 
-				request.counter++;
-
-				resolve(fetch(resolve_url(request.url, res.headers.location), request));
+				resolve(fetch(resolve_url(request.url, res.headers.location), new Request(request.url, opts)));
 				return;
 			}
 

--- a/src/request.js
+++ b/src/request.js
@@ -39,7 +39,7 @@ export default class Request {
 			parsedURL = parse_url(input.url);
 		}
 
-		let method = init.method || input.method || 'GET';
+		const method = init.method || input.method || 'GET';
 
 		if ((init.body != null || input instanceof Request && input.body !== null) &&
 			(method === 'GET' || method === 'HEAD')) {
@@ -58,9 +58,31 @@ export default class Request {
 		});
 
 		// fetch spec options
-		this.method = method.toUpperCase();
-		this.redirect = init.redirect || input.redirect || 'follow';
-		this.headers = new Headers(init.headers || input.headers || {});
+		const redirect = init.redirect || input.redirect || 'follow';
+		const headers = new Headers(init.headers || input.headers || {});
+
+		Object.defineProperties(this, {
+			method: {
+				get() { return method.toUpperCase() },
+				set() {},
+				enumerable: true,
+			},
+			redirect: {
+				get() { return redirect },
+				set() {},
+				enumerable: true,
+			},
+			headers: {
+				get() { return headers },
+				set() {},
+				enumerable: true,
+			},
+			url: {
+				get() { return format_url(this[PARSED_URL]) },
+				set() {},
+				enumerable: true,
+			},
+		});
 
 		if (init.body != null) {
 			const contentType = extractContentType(this);
@@ -86,10 +108,8 @@ export default class Request {
 			enumerable: false,
 			configurable: true
 		});
-	}
 
-	get url() {
-		return format_url(this[PARSED_URL]);
+		return Object.create(this);
 	}
 
 	/**

--- a/src/response.js
+++ b/src/response.js
@@ -21,11 +21,38 @@ export default class Response {
 	constructor(body = null, opts = {}) {
 		Body.call(this, body, opts);
 
-		this.url = opts.url;
-		this.status = opts.status || 200;
-		this.statusText = opts.statusText || STATUS_CODES[this.status];
+		const url = opts.url;
+		const status = opts.status || 200;
+		const statusText = opts.statusText || STATUS_CODES[status];
+		const headers = new Headers(opts.headers);
 
-		this.headers = new Headers(opts.headers);
+		Object.defineProperties(this, {
+			url: {
+				get() { return url },
+				set() {},
+				enumerable: true,
+			},
+			status: {
+				get() { return status },
+				set() {},
+				enumerable: true,
+			},
+			statusText: {
+				get() { return statusText },
+				set() {},
+				enumerable: true,
+			},
+			headers: {
+				get() { return headers; },
+				set() {},
+				enumerable: true,
+			},
+			ok: {
+				get() { return this.status >= 200 && this.status < 300},
+				set() {},
+				enumerable: true,
+			}
+		});
 
 		Object.defineProperty(this, Symbol.toStringTag, {
 			value: 'Response',
@@ -33,13 +60,8 @@ export default class Response {
 			enumerable: false,
 			configurable: true
 		});
-	}
 
-	/**
-	 * Convenience property representing if the request ended normally
-	 */
-	get ok() {
-		return this.status >= 200 && this.status < 300;
+		return Object.create(this);
 	}
 
 	/**

--- a/test/test.js
+++ b/test/test.js
@@ -91,6 +91,122 @@ describe('node-fetch', () => {
 		expect(Request).to.equal(RequestOrig);
 	});
 
+	describe('Response', function() {
+		it('does not provide own enumerable properties', function() {
+			const response = new Response({
+				headers: new Headers({ 'x-custom-header': 1337 }),
+				url: 'my.url',
+				status: 200,
+				statusText: 'yay',
+			});
+			expect(Object.getOwnPropertyNames(response)).to.be.empty;
+		});
+
+		it('does provide enumerable properties', function() {
+			const response = new Response({
+				headers: new Headers({ 'x-custom-header': 1337 }),
+				url: 'my.url',
+				status: 200,
+				statusText: 'yay',
+			});
+			const enumerableProperties = [];
+			for (const property in response) {
+				enumerableProperties.push(property);
+			}
+			['headers', 'ok', 'url', 'status', 'statusText'].forEach(
+				property => expect(enumerableProperties).to.contain(property)
+			);
+		});
+
+		describe('defines the readOnly property', function() {
+			const response = new Response('', {
+				headers: new Headers({ 'x-custom-header': 1337 }),
+				url: 'my.url',
+				status: 200,
+				statusText: 'yay',
+			});
+
+			it('headers', function() {
+				response.headers = new Headers({ 'x-custom-header': 42 });
+				expect(response.headers).to.eql(new Headers({ 'x-custom-header': 1337 }));
+			});
+
+			it('ok', function() {
+				response.ok = false;
+				expect(response.ok).to.be.true;
+			});
+
+			it('status', function() {
+				response.status = 400;
+				expect(response.status).to.equal(200);
+			});
+
+			it('statusText', function() {
+				response.statusText = 'edited';
+				expect(response.statusText).to.equal('yay');
+			});
+
+			it('url', function() {
+				response.url = 'edited';
+				expect(response.url).to.equal('my.url');
+			});
+        });
+	});
+
+	describe('Request', function() {
+		it('does not provide own enumerable properties', function() {
+			const request = new Request('my.url', {
+				method: 'GET',
+				headers: new Headers({ 'x-custom-header': 1337 }),
+				redirect: 'follow',
+			});
+			expect(Object.getOwnPropertyNames(request)).to.be.empty;
+		});
+
+		it('does provide enumerable properties', function() {
+			const request = new Request('my.url', {
+				method: 'GET',
+				headers: new Headers({ 'x-custom-header': 1337 }),
+				redirect: 'follow',
+			});
+			const enumerableProperties = [];
+			for (const property in request) {
+				enumerableProperties.push(property);
+			}
+			['method', 'url', 'headers', 'redirect'].forEach(
+				property => expect(enumerableProperties).to.contain(property)
+			);
+		});
+
+		describe ('defines the readOnly property', function() {
+			const request = new Request('my.url', {
+				method: 'GET',
+				headers: new Headers({ 'x-custom-header': 1337 }),
+				redirect: 'follow',
+			});
+
+			it('method', function() {
+				request.method = 'PUT';
+				expect(request.method).to.equal('GET');
+			});
+
+			it('url', function() {
+				request.url = 'edited';
+				expect(request.url).to.equal('my.url');
+			});
+
+			it('headers', function() {
+				request.headers = new Headers({ 'x-custom-header': 'edited' });
+				expect(request.headers).to.eql(new Headers({ 'x-custom-header': 1337 }));
+			});
+
+			it('redirect', function() {
+				request.redirect = 'error';
+				expect(request.redirect).to.equal('follow');
+			});
+		});
+	});
+
 	(supportToString ? it : it.skip)('should support proper toString output for Headers, Response and Request objects', function() {
 		expect(new Headers().toString()).to.equal('[object Headers]');
 		expect(new Response().toString()).to.equal('[object Response]');


### PR DESCRIPTION
recently my team wrote test code like this:

```js
// business code
const jsonBody = response.json ? await response.json().catch(() => null) : null;
const responseWithJsonBody = Object.assign ({}, response, { jsonBody: jsonBody });
return responseWithJsonBody.ok ? responseWithJsonBody : Promise.reject (responseWithJsonBody);

// test
expect(errorResponse.status).toBe(400);
expect(errorResponse.ok).toBe(false);
expect(errorResponse.jsonBody).toBeNull();
```

I don't want to discuss this code snippet...
but using `Object.assign` to create a new response object with additional stuff doesn't break the test currently. However, in the real world all `Response`attributes are not enumerable and therefore are not copied with `Object.assign`.

imho this lib should ensure the real world behaviour =)
