### PR TITLE
Check for illegal keys in the options argument

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -10,7 +10,7 @@ import Body, { clone, extractContentType, getTotalBytes } from './body';
 
 const { format: format_url, parse: parse_url } = require('url');
 
-const ALLOWED_OPTIONS = ['method', 'headers', 'body', 'redirect', 'follow', 'timeout', 'compress', 'size', 'agent'];
+const ALLOWED_OPTIONS = ['method', 'headers', 'body', 'redirect', 'follow', 'timeout', 'compress', 'size', 'agent', 'counter'];
 const PARSED_URL = Symbol('url');
 
 /**

--- a/src/request.js
+++ b/src/request.js
@@ -10,6 +10,7 @@ import Body, { clone, extractContentType, getTotalBytes } from './body';
 
 const { format: format_url, parse: parse_url } = require('url');
 
+const ALLOWED_OPTIONS = ['method', 'headers', 'body', 'redirect', 'follow', 'timeout', 'compress', 'size', 'agent'];
 const PARSED_URL = Symbol('url');
 
 /**
@@ -38,7 +39,13 @@ export default class Request {
 		} else {
 			parsedURL = parse_url(input.url);
 		}
-
+		
+		let illegalKeys = Objecy.keys(init).filter((key) => !ALLOWED_OPTIONS.includes(key));
+		
+		if (illegalKeys.length > 0) {
+			throw new TypeError(`Request options cannot contain keys ${illegalKeys.join(', ')}`);
+		}
+    
 		let method = init.method || input.method || 'GET';
 
 		if ((init.body != null || input instanceof Request && input.body !== null) &&

--- a/src/request.js
+++ b/src/request.js
@@ -40,7 +40,7 @@ export default class Request {
 			parsedURL = parse_url(input.url);
 		}
 		
-		let illegalKeys = Object.keys(init).filter((key) => !ALLOWED_OPTIONS.includes(key));
+		let illegalKeys = Object.keys(init).filter((key) => !~ALLOWED_OPTIONS.indexOf(key));
 		
 		if (illegalKeys.length > 0) {
 			throw new TypeError(`Request options cannot contain keys ${illegalKeys.join(', ')}`);

--- a/src/request.js
+++ b/src/request.js
@@ -40,7 +40,7 @@ export default class Request {
 			parsedURL = parse_url(input.url);
 		}
 		
-		let illegalKeys = Objecy.keys(init).filter((key) => !ALLOWED_OPTIONS.includes(key));
+		let illegalKeys = Object.keys(init).filter((key) => !ALLOWED_OPTIONS.includes(key));
 		
 		if (illegalKeys.length > 0) {
 			throw new TypeError(`Request options cannot contain keys ${illegalKeys.join(', ')}`);

--- a/test/test.js
+++ b/test/test.js
@@ -97,6 +97,11 @@ describe('node-fetch', () => {
 		expect(new Request(base).toString()).to.equal('[object Request]');
 	});
 
+	it('should reject with error if illegal options are passed', function() {
+		url = `${base}hello`;
+		return expect(fetch(url,  {data: 'test', foo: 'bar', method: 'GET'})).to.eventually.be.rejectedWith(TypeError, 'Request options cannot contain keys data, foo');
+	});
+	
 	it('should reject with error if url is protocol relative', function() {
 		url = '//example.com/';
 		return expect(fetch(url)).to.eventually.be.rejectedWith(TypeError, 'Only absolute URLs are supported');


### PR DESCRIPTION
I was writing some script and I spent literally 1 to 2 hours pulling my head out as to why the server was responding with 500 when same curl was working just fine. Turns out I used the field `data` instead of `body`. This could have been avoided if I used TypeScript, or if node-fetch checked for illegal options. 

