### PR TITLE
Added a more updated alternative to isomorphic-fetch on README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A light-weight module that brings `window.fetch` to Node.js
 
 Instead of implementing `XMLHttpRequest` in Node.js to run browser-specific [Fetch polyfill](https://github.com/github/fetch), why not go from native `http` to `fetch` API directly? Hence `node-fetch`, minimal code for a `window.fetch` compatible API on Node.js runtime.
 
-See Matt Andrews' [isomorphic-fetch](https://github.com/matthew-andrews/isomorphic-fetch) for isomorphic usage (exports `node-fetch` for server-side, `whatwg-fetch` for client-side).
+See [cross-fetch](https://github.com/lquixada/cross-fetch) for isomorphic usage (exports `node-fetch` for server-side, `whatwg-fetch` for client-side).
 
 
 ## Features


### PR DESCRIPTION
isomorphic-fetch hasn't been updated for a while, so cross-fetch was created in order to provide a more updated, flexible and [fixed](https://github.com/matthew-andrews/isomorphic-fetch/issues/125) alternative to the community.