### PR TITLE
Test against Node.js v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "4"
   - "6"
+  - "8"
   - "node"
 env:
   - FORMDATA_VERSION=1.0.0


### PR DESCRIPTION
Node.js v9 is out so we need to specify testing against v8