### PR TITLE
Add 'rawBody' options for preventing *zip decoding

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,12 +131,13 @@ export default function fetch(url, opts) {
 			// HTTP-network fetch step 16.1.3: handle content codings
 
 			// in following scenarios we ignore compression support
-			// 1. compression support is disabled
-			// 2. HEAD request
-			// 3. no Content-Encoding header
-			// 4. no content response (204)
-			// 5. content not modified response (304)
-			if (!request.compress || request.method === 'HEAD' || codings === null || res.statusCode === 204 || res.statusCode === 304) {
+			// 1. `rawBody` option is setted up in true
+			// 2. compression support is disabled
+			// 3. HEAD request
+			// 4. no Content-Encoding header
+			// 5. no content response (204)
+			// 6. content not modified response (304)
+			if (request.rawBody || !request.compress || request.method === 'HEAD' || codings === null || res.statusCode === 204 || res.statusCode === 304) {
 				resolve(new Response(body, response_options));
 				return;
 			}

--- a/src/request.js
+++ b/src/request.js
@@ -79,6 +79,7 @@ export default class Request {
 			input.compress : true;
 		this.counter = init.counter || input.counter || 0;
 		this.agent = init.agent || input.agent;
+		this.rawBody = init.rawBody || input.rawBody;
 
 		this[PARSED_URL] = parsedURL;
 		Object.defineProperty(this, Symbol.toStringTag, {

--- a/test/test.js
+++ b/test/test.js
@@ -577,6 +577,17 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should skip decompression if "rawBody" option setted up in true', function() {
+		url = `${base}gzip`;
+		return fetch(url, {
+			rawBody: true
+		}).then(res => {
+			return res.text().then(result => {
+				expect(result).not.to.equal('hello world');
+			});
+		});
+	})
+
 	it('should reject if response compression is invalid', function() {
 		url = `${base}invalid-content-encoding`;
 		return fetch(url).then(res => {


### PR DESCRIPTION
Hello.

This POC pr brings ability to prevent gzip decoding even the `compress` option was set up as `true`. It's can be useful if you are want to work with raw body (decompress it yourself or just pass through).

What are you think about this, guys?