### PR TITLE
307 redirect with PATCH & body

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@
  * index.js
  *
  * a request API compatible with window.fetch
+ *
+ * All spec algorithm step numbers are based on https://fetch.spec.whatwg.org/commit-snapshots/ae716822cb3a61843226cd090eefc6589446c1d2/.
  */
 
 import Body, { writeToStream, getTotalBytes } from './body';
@@ -141,10 +143,10 @@ export default function fetch(url, opts) {
 				, timeout: request.timeout
 			};
 
-			// HTTP-network fetch step 16.1.2
+			// HTTP-network fetch step 12.1.1.3
 			const codings = headers.get('Content-Encoding');
 
-			// HTTP-network fetch step 16.1.3: handle content codings
+			// HTTP-network fetch step 12.1.1.4: handle content codings
 
 			// in following scenarios we ignore compression support
 			// 1. compression support is disabled

--- a/src/request.js
+++ b/src/request.js
@@ -3,6 +3,8 @@
  * request.js
  *
  * Request class contains server only options
+ *
+ * All spec algorithm step numbers are based on https://fetch.spec.whatwg.org/commit-snapshots/ae716822cb3a61843226cd090eefc6589446c1d2/.
  */
 
 import Headers from './headers.js';
@@ -151,7 +153,7 @@ export function getNodeRequestOptions(request) {
 	const parsedURL = request[INTERNALS].parsedURL;
 	const headers = new Headers(request[INTERNALS].headers);
 
-	// fetch step 3
+	// fetch step 1.3
 	if (!headers.has('Accept')) {
 		headers.set('Accept', '*/*');
 	}
@@ -165,7 +167,7 @@ export function getNodeRequestOptions(request) {
 		throw new TypeError('Only HTTP(S) protocols are supported');
 	}
 
-	// HTTP-network-or-cache fetch steps 5-9
+	// HTTP-network-or-cache fetch steps 2.4-2.7
 	let contentLengthValue = null;
 	if (request.body == null && /^(POST|PUT)$/i.test(request.method)) {
 		contentLengthValue = '0';
@@ -180,12 +182,12 @@ export function getNodeRequestOptions(request) {
 		headers.set('Content-Length', contentLengthValue);
 	}
 
-	// HTTP-network-or-cache fetch step 12
+	// HTTP-network-or-cache fetch step 2.11
 	if (!headers.has('User-Agent')) {
 		headers.set('User-Agent', 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)');
 	}
 
-	// HTTP-network-or-cache fetch step 16
+	// HTTP-network-or-cache fetch step 2.15
 	if (request.compress) {
 		headers.set('Accept-Encoding', 'gzip,deflate');
 	}
@@ -193,7 +195,7 @@ export function getNodeRequestOptions(request) {
 		headers.set('Connection', 'close');
 	}
 
-	// HTTP-network fetch step 4
+	// HTTP-network fetch step 4.2
 	// chunked encoding is handled by Node.js
 
 	return Object.assign({}, parsedURL, {

--- a/test/server.js
+++ b/test/server.js
@@ -250,9 +250,8 @@ export default class TestServer {
 			res.end();
 		}
 
-		if (p === '/error/redirect') {
+		if (p === '/redirect/no-location') {
 			res.statusCode = 301;
-			//res.setHeader('Location', '/inspect');
 			res.end();
 		}
 

--- a/test/test.js
+++ b/test/test.js
@@ -273,6 +273,22 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should follow PATCH request redirect code 301 with PATCH', function() {
+		url = `${base}redirect/301`;
+		opts = {
+			method: 'PATCH'
+			, body: 'a=1'
+		};
+		return fetch(url, opts).then(res => {
+			expect(res.url).to.equal(`${base}inspect`);
+			expect(res.status).to.equal(200);
+			return res.json().then(res => {
+				expect(res.method).to.equal('PATCH');
+				expect(res.body).to.equal('a=1');
+			});
+		});
+	});
+
 	it('should follow POST request redirect code 302 with GET', function() {
 		url = `${base}redirect/302`;
 		opts = {
@@ -289,6 +305,22 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should follow PATCH request redirect code 302 with PATCH', function() {
+		url = `${base}redirect/302`;
+		opts = {
+			method: 'PATCH'
+			, body: 'a=1'
+		};
+		return fetch(url, opts).then(res => {
+			expect(res.url).to.equal(`${base}inspect`);
+			expect(res.status).to.equal(200);
+			return res.json().then(res => {
+				expect(res.method).to.equal('PATCH');
+				expect(res.body).to.equal('a=1');
+			});
+		});
+	});
+
 	it('should follow redirect code 303 with GET', function() {
 		url = `${base}redirect/303`;
 		opts = {
@@ -301,6 +333,22 @@ describe('node-fetch', () => {
 			return res.json().then(result => {
 				expect(result.method).to.equal('GET');
 				expect(result.body).to.equal('');
+			});
+		});
+	});
+
+	it('should follow PATCH request redirect code 307 with PATCH', function() {
+		url = `${base}redirect/307`;
+		opts = {
+			method: 'PATCH'
+			, body: 'a=1'
+		};
+		return fetch(url, opts).then(res => {
+			expect(res.url).to.equal(`${base}inspect`);
+			expect(res.status).to.equal(200);
+			return res.json().then(result => {
+				expect(result.method).to.equal('PATCH');
+				expect(result.body).to.equal('a=1');
 			});
 		});
 	});
@@ -383,15 +431,17 @@ describe('node-fetch', () => {
 		});
 	});
 
-	it('should reject broken redirect', function() {
-		url = `${base}error/redirect`;
-		return expect(fetch(url)).to.eventually.be.rejected
-			.and.be.an.instanceOf(FetchError)
-			.and.have.property('type', 'invalid-redirect');
+	it('should treat broken redirect as ordinary response (follow)', function() {
+		url = `${base}redirect/no-location`;
+		return fetch(url, opts).then(res => {
+			expect(res.url).to.equal(url);
+			expect(res.status).to.equal(301);
+			expect(res.headers.get('location')).to.be.null;
+		});
 	});
 
-	it('should not reject broken redirect under manual redirect', function() {
-		url = `${base}error/redirect`;
+	it('should treat broken redirect as ordinary response (manual)', function() {
+		url = `${base}redirect/no-location`;
 		opts = {
 			redirect: 'manual'
 		};


### PR DESCRIPTION
When the server returns a 307 redirect, `node-fetch` does not post the request body to the new URL, but `fetch` does, at least in Chrome.

Here is a failing test from https://github.com/octokit/rest.js/pull/764

https://travis-ci.org/octokit/rest.js/jobs/348045840#L4095

The same test passes when run in Chrome

https://travis-ci.org/octokit/rest.js/jobs/348045843#L4040

I tried to create a test case to reproduce the problem, does that look good? I’m not sure how to fix it though, I’d appreciate pointers :)