### PR TITLE
Reject when stream accumulation fails (Fix #414)

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -257,7 +257,13 @@ function consumeBody() {
 			}
 
 			clearTimeout(resTimeout);
-			resolve(Buffer.concat(accum));
+
+			try {
+				resolve(Buffer.concat(accum));
+			} catch (err) {
+				// handle streams that have accumulated too much data (issue #414)
+				reject(new FetchError(`Could not create Buffer from response body for ${this.url}: ${err.message}`, 'system', err));
+			}
 		});
 	});
 }

--- a/test/test.js
+++ b/test/test.js
@@ -16,7 +16,6 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const stream = require('stream');
-const buffer = require('buffer');
 const { parse: parseURL, URLSearchParams } = require('url');
 
 let convert;
@@ -1434,6 +1433,7 @@ describe('node-fetch', () => {
 		body = body.pipe(new stream.PassThrough());
 		const res = new Response(body);
 		const bufferConcat = Buffer.concat;
+		const restoreBufferConcat = () => Buffer.concat = bufferConcat;
 		Buffer.concat = () => { throw new Error('embedded error'); };
 
 		return res.text().then(() => chai.assert(false)).catch(err => {
@@ -1441,7 +1441,7 @@ describe('node-fetch', () => {
 				.and.include({ type: 'system' })
 				.and.have.property('message').that.includes('Could not create Buffer')
 				.and.that.includes('embedded error');
-		}).then(() => Buffer.concat = bufferConcat);
+		}).then(restoreBufferConcat, restoreBufferConcat);
 	});
 });
 


### PR DESCRIPTION
I'm not totally sure whether we should reject this as a `FetchError`, so please let me know, if not (and I'll update the PR accordingly). The underlying error here should always be a `RangeError`.

As for testing: unfortunately, there doesn't appear to be any great way to test this (the `RangeError` is thrown when the buffer size is larger than the maximum allowed by v8 itself, which isn't configurable from within the tests). The best I could do here was to temporarily overwrite `Buffer.concat`, which is used by node-fetch internally, to force it to throw an error, and then insure that the error is passed on via a `Promise` rejection.