### PR TITLE
wrapped ArrayBuffer with buffer internally to fix body methods

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -206,7 +206,7 @@ function consumeBody() {
 
 	// body is buffer
 	if (Object.prototype.toString.call(this.body) === '[object ArrayBuffer]') {
-		return Body.Promise.resolve(this.body);
+		return Body.Promise.resolve(new Buffer(this.body));
 	}
 
 	// istanbul ignore if: should never happen

--- a/src/body.js
+++ b/src/body.js
@@ -206,7 +206,7 @@ function consumeBody() {
 
 	// body is buffer
 	if (Object.prototype.toString.call(this.body) === '[object ArrayBuffer]') {
-		return Body.Promise.resolve(new Buffer(this.body));
+		return Body.Promise.resolve(Buffer.from(this.body));
 	}
 
 	// istanbul ignore if: should never happen

--- a/test/test.js
+++ b/test/test.js
@@ -1771,6 +1771,13 @@ describe('Response', function () {
 		});
 	});
 
+	it('should support ArrayBuffer as body', function() {
+		const res = new Response(stringToArrayBuffer('a=1'));
+		return res.text().then(result => {
+			expect(result).to.equal('a=1');
+		});
+	});
+
 	it('should support blob as body', function() {
 		const res = new Response(new Blob(['a=1']));
 		return res.text().then(result => {
@@ -1971,6 +1978,16 @@ describe('Request', function () {
 		return Promise.all([cl.text(), req.text()]).then(results => {
 			expect(results[0]).to.equal('a=1');
 			expect(results[1]).to.equal('a=1');
+		});
+	});
+
+	it('should support ArrayBuffer as body', function() {
+		const req = new Request('', {
+			method: 'POST',
+			body: stringToArrayBuffer('a=1')
+		});
+		return req.text().then(result => {
+			expect(result).to.equal('a=1');
 		});
 	});
 });


### PR DESCRIPTION
Initializing `Request` and `Response` with array buffers causes issues for `.text()`:
```javascript
const { Response } = require('node-fetch');

const response = new Response(new Uint8Array[97]);
response.text().then(text => {
    // text === '[object ArrayBuffer]', should be 'a'
});
```

The problem is due to the fact that `ArrayBuffer.toString()` returns `[object ArrayBuffer]` instead of decoding the `ArrayBuffer`. Converting the `ArrayBuffer` to a `Buffer` fixes `.text()` and `.json()`.