### PR TITLE
Fix redirection: response object must be consumed otherwise process gets stuck

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -128,6 +128,7 @@ export default function fetch(url, opts) {
 
 						// HTTP-redirect fetch step 15
 						resolve(fetch(new Request(locationURL, requestOpts)));
+						res.on('data', () => {}) // response *must* be consumed otherwise it gets stuck forever
 						return;
 				}
 			}


### PR DESCRIPTION
Fixes https://github.com/bitinn/node-fetch/issues/428

> If no 'response' handler is added, then the response will be entirely discarded. However, if a 'response' event handler is added, then the data from the response object must be consumed, either by calling response.read() whenever there is a 'readable' event, or by adding a 'data' handler, or by calling the .resume() method. Until the data is consumed, the 'end' event will not fire. Also, until the data is read it will consume memory that can eventually lead to a 'process out of memory' error.

https://nodejs.org/api/http.html#http_event_response