### PR TITLE
Support TypeScript import in browser

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,4 +1,8 @@
 module.exports = exports = window.fetch;
+
+// Needed for TypeScript.
+exports.default = window.fetch;
+
 exports.Headers = window.Headers;
 exports.Request = window.Request;
 exports.Response = window.Response;


### PR DESCRIPTION
Related to #307 and #332.

TypeScript is compiling
```
import fetch from 'node-fetch';
fetch(url, options)
```
into
```
const node_fetch_1 = require("node-fetch");
node_fetch_1.default(url, options)
```

This works great in Node.js thanks to #332 but doesn't work in the browser (I'm using Webpack, so it correctly uses the `browser.js` script specified in `package.json`).