### PR TITLE
Bind fetch to window in the browser

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,7 +1,7 @@
 module.exports = exports = window.fetch;
 
-// Needed for TypeScript.
-exports.default = window.fetch;
+// Needed for TypeScript and Webpack.
+exports.default = window.fetch.bind(window);
 
 exports.Headers = window.Headers;
 exports.Request = window.Request;


### PR DESCRIPTION
Fixes `fetch` illegal invocation errors in Chrome. This is the same as https://github.com/developit/unfetch/pull/47

As mentioned [here](https://github.com/bitinn/node-fetch/pull/433#issuecomment-375917867), there's an issue in some browsers and Webpack with fetch not being bound to `window` in Webpack.