### PR TITLE
Pass family

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ The following node-fetch extension properties are provided:
 - `compress`
 - `counter`
 - `agent`
+- `family`
 
 See [options](#fetch-options) for exact meaning of these extensions.
 

--- a/src/request.js
+++ b/src/request.js
@@ -201,6 +201,7 @@ export function getNodeRequestOptions(request) {
 	return Object.assign({}, parsedURL, {
 		method: request.method,
 		headers: exportNodeCompatibleHeaders(headers),
-		agent: request.agent
+		agent: request.agent,
+		family: request.family
 	});
 }


### PR DESCRIPTION
In order to be able to select the IP type when DNS querying, `family` needs to be proxied from the options passed.