### PR TITLE
Passing through original request timeout on new requests generated fr…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,8 @@ export default function fetch(url, opts) {
 							agent: request.agent,
 							compress: request.compress,
 							method: request.method,
-							body: request.body
+							body: request.body,
+							timeout: request.timeout
 						};
 
 						// HTTP-redirect fetch step 9

--- a/test/server.js
+++ b/test/server.js
@@ -264,6 +264,12 @@ export default class TestServer {
 			res.end();
 		}
 
+		if (p === '/redirect/chain/timeout') {
+			res.statusCode = 301;
+			res.setHeader('Location', '/timeout');
+			res.end();
+		}
+
 		if (p === '/redirect/no-location') {
 			res.statusCode = 301;
 			res.end();

--- a/test/test.js
+++ b/test/test.js
@@ -749,6 +749,18 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should allow custom timeout on redirects, reject case', function() {
+		this.timeout(500);
+		const url = `${base}redirect/chain/timeout`;
+		const opts = {
+			follow: 2,
+			timeout: 100
+		}
+		return expect(fetch(url, opts)).to.eventually.be.rejected
+			.and.be.an.instanceOf(FetchError)
+			.and.have.property('type', 'request-timeout');
+	});
+
 	it('should clear internal timeout on fetch response', function (done) {
 		this.timeout(2000);
 		spawn('node', ['-e', `require('./')('${base}hello', { timeout: 10000 })`])


### PR DESCRIPTION
The timeout option wasn't working as I would expect it to when redirects are followed. If a custom timeout of, say 100ms is specified, and the second link in the redirect chain takes 500ms to respond, the custom timeout is NOT honored.

This change passes through the original request timeout to each subsequent redirect request so that a request-timeout error would be thrown instead of waiting longer than desired.

According to the documentation:
"req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies)" it's unclear whether "resets" means unlimited timeouts on followed redirects, or if it's supposed to reset to the original request custom timeout. I think the latter makes more sense.