### PR TITLE
Add support for ArrayBufferView as Request Body

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -39,7 +39,10 @@ export default function Body(body, {
 	} else if (body instanceof Blob) {
 		// body is blob
 	} else if (Buffer.isBuffer(body)) {
-		// body is buffer
+        // body is buffer
+    } else if (body.buffer instanceof ArrayBuffer) {
+		// body is ArrayBuffer or inherits from ArrayBufferView
+        body = body.buffer
 	} else if (Object.prototype.toString.call(body) === '[object ArrayBuffer]') {
 		// body is array buffer
 	} else if (body instanceof Stream) {

--- a/test/test.js
+++ b/test/test.js
@@ -2051,35 +2051,55 @@ describe('Request', function () {
 
     it('should support Uint8Array as body', function() {
     	const data = new Uint8Array(3);
-        data[0] = 'a';
-        data[1] = '=';
-        data[2] = '1';
+        data[0] = 1;
+        data[1] = 2;
+        data[2] = 3;
         const req = new Request('', {
             method: 'POST',
             body: data
         });
         return req.buffer().then(result => {
-            expect(result[0]).to.equal(data[0]);
-            expect(result[1]).to.equal(data[1]);
-            expect(result[2]).to.equal(data[2]);
-            expect(result.byteLength).to.equal(data.byteLength)
+            expect(result[0]).to.equal(1);
+            expect(result[1]).to.equal(2);
+            expect(result[2]).to.equal(3);
+            expect(result.byteLength).to.equal(3)
         });
     });
 
     it('should support Uint16Array as body', function() {
-        const data = new Uint8Array(3);
-        data[0] = 'a';
-        data[1] = '=';
-        data[2] = '1';
+        const data = new Uint16Array(3);
+        data[0] = 1;
+        data[1] = 2;
+        data[2] = 3;
         const req = new Request('', {
             method: 'POST',
             body: data
         });
         return req.buffer().then(result => {
-            expect(result[0]).to.equal(data[0]);
-            expect(result[1]).to.equal(data[1]);
-            expect(result[2]).to.equal(data[2]);
-            expect(result.byteLength).to.equal(data.byteLength)
+            const res = new Uint16Array(result.buffer);
+            expect(res[0]).to.equal(1);
+            expect(res[1]).to.equal(2);
+            expect(res[2]).to.equal(3);
+            expect(res.byteLength).to.equal(6);
+            expect(res.length).to.equal(3);
+        });
+    });
+    it('should support Float64Array as body', function() {
+        const data = new Float64Array(3);
+        data[0] = -1.0;
+        data[1] = -2.0;
+        data[2] = -3.0;
+        const req = new Request('', {
+            method: 'POST',
+            body: data
+        });
+        return req.buffer().then(result => {
+            const res = new Float64Array(result.buffer);
+            expect(res[0]).to.equal(-1.0);
+            expect(res[1]).to.equal(-2.0);
+            expect(res[2]).to.equal(-3.0);
+            expect(res.byteLength).to.equal(24);
+            expect(res.length).to.equal(3);
         });
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -2048,6 +2048,40 @@ describe('Request', function () {
 			expect(result).to.equal('a=1');
 		});
 	});
+
+    it('should support Uint8Array as body', function() {
+    	const data = new Uint8Array(3);
+        data[0] = 'a';
+        data[1] = '=';
+        data[2] = '1';
+        const req = new Request('', {
+            method: 'POST',
+            body: data
+        });
+        return req.buffer().then(result => {
+            expect(result[0]).to.equal(data[0]);
+            expect(result[1]).to.equal(data[1]);
+            expect(result[2]).to.equal(data[2]);
+            expect(result.byteLength).to.equal(data.byteLength)
+        });
+    });
+
+    it('should support Uint16Array as body', function() {
+        const data = new Uint8Array(3);
+        data[0] = 'a';
+        data[1] = '=';
+        data[2] = '1';
+        const req = new Request('', {
+            method: 'POST',
+            body: data
+        });
+        return req.buffer().then(result => {
+            expect(result[0]).to.equal(data[0]);
+            expect(result[1]).to.equal(data[1]);
+            expect(result[2]).to.equal(data[2]);
+            expect(result.byteLength).to.equal(data.byteLength)
+        });
+    });
 });
 
 function streamToPromise(stream, dataHandler) {


### PR DESCRIPTION
ArrayBuffers like Uint8Array were treated like strings and converted to strings, leading to wrong body payloads in i.e. POST requests.
I also added some tests for Uint8Array, Uint16Array and Float64Array.
This fixes #459 and maybe also #457, for which the build was failing.