### PR TITLE
Refine README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,19 @@ fetch('http://domain.invalid/')
 
 fetch('https://assets-cdn.github.com/images/modules/logos_page/Octocat.png')
 	.then(res => {
-		const dest = fs.createWriteStream('./octocat.png', {
-			autoClose: true,
+		return new Promise((resolve, reject) => {
+			const dest = fs.createWriteStream('./octocat.png');
+			res.body.pipe(dest);
+			res.body.on('error', err => {
+				reject(err);
+			});
+			dest.on('finish', () => {
+				resolve();
+			});
+			dest.on('error', err => {
+				reject(err);
+			});
 		});
-		res.body.pipe(dest);
 	});
 
 // buffer


### PR DESCRIPTION
This reverts commit fa6548ed316a3c512147a3bb4f4d6e986d738be6 (#441).

The autoClose option has been true by default since at least Node.js
v6.0.0. There is no need to set it once more.

Instead, make the example more realistic by handling stream outcomes
using a promise.

See #375.