### PR TITLE
support option `lookup` for custom dns resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ The default values are shown after each option key.
 	compress: true,     // support gzip/deflate content encoding. false to disable
 	size: 0,            // maximum response body size in bytes. 0 to disable
 	agent: null         // http(s).Agent instance, allows custom proxy, certificate etc.
+	lookup: dns.lookup  // custom dns lookup function for socket
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,8 @@ export default function fetch(url, opts) {
 							agent: request.agent,
 							compress: request.compress,
 							method: request.method,
-							body: request.body
+							body: request.body,
+							lookup: request.lookup
 						};
 
 						// HTTP-redirect fetch step 9

--- a/src/request.js
+++ b/src/request.js
@@ -98,6 +98,7 @@ export default class Request {
 			input.compress : true;
 		this.counter = init.counter || input.counter || 0;
 		this.agent = init.agent || input.agent;
+		this.lookup = init.lookup || input.lookup;
 	}
 
 	get method() {
@@ -201,6 +202,7 @@ export function getNodeRequestOptions(request) {
 	return Object.assign({}, parsedURL, {
 		method: request.method,
 		headers: exportNodeCompatibleHeaders(headers),
-		agent: request.agent
+		agent: request.agent,
+		lookup: request.lookup
 	});
 }

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,7 @@ import FormData from 'form-data';
 import stringToArrayBuffer from 'string-to-arraybuffer';
 import URLSearchParams_Polyfill from 'url-search-params';
 import { URL } from 'whatwg-url';
+import { lookup } from 'dns';
 
 const { spawn } = require('child_process');
 const http = require('http');
@@ -1530,6 +1531,30 @@ describe('node-fetch', () => {
 			.and.include({ type: 'system' })
 			.and.have.property('message').that.includes('Could not create Buffer')
 			.and.that.includes('embedded error');
+	});
+
+	it("should call a custom `lookup` function", function() {
+		const url = `${base}hello`;
+		let called = 0;
+		function lookupSpy(hostname, options, callback) {
+			called++;
+			return lookup(hostname, options, callback);
+		}
+		return fetch(url, { lookup: lookupSpy }).then(() => {
+			expect(called).to.equal(1);
+		});
+	});
+
+	it("should use the custom `lookup` function for redirects", function() {
+		const url = `${base}redirect/301`;
+		let called = 0;
+		function lookupSpy(hostname, options, callback) {
+			called++;
+			return lookup(hostname, options, callback);
+		}
+		return fetch(url, { lookup: lookupSpy }).then(() => {
+			expect(called).to.equal(2);
+		});
 	});
 });
 


### PR DESCRIPTION
This enables the use of modules like [lookup-dns-cache](https://www.npmjs.com/package/lookup-dns-cache) to cache dns requests and work around the [thread pool issues caused by dns.lookup](https://nodejs.org/api/dns.html#dns_implementation_considerations).

Adding this functionality here should eliminte the need for complex decorators like [@zeit/fetch-cached-dns](https://www.npmjs.com/package/@zeit/fetch-cached-dns).