### PR TITLE
support socket options (son of #256, #445 and #473)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ The default values are shown after each option key.
 	size: 0,            // maximum response body size in bytes. 0 to disable
 	agent: null         // http(s).Agent instance, allows custom proxy, certificate etc.
 	lookup: dns.lookup  // custom dns lookup function for socket
+	family: null        // numbers 4 or 6 to limit dns resolution to ip v4 or v6
+	localAddress: null  // local interface to bind to for network connections
 }
 ```
 
@@ -257,6 +259,8 @@ The following node-fetch extension properties are provided:
 - `counter`
 - `agent`
 - `family`
+- `lookup`
+- `localAddress`
 
 See [options](#fetch-options) for exact meaning of these extensions.
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ The default values are shown after each option key.
 	compress: true,     // support gzip/deflate content encoding. false to disable
 	size: 0,            // maximum response body size in bytes. 0 to disable
 	agent: null         // http(s).Agent instance, allows custom proxy, certificate etc.
+	lookup: dns.lookup  // custom dns lookup function for socket
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ The following node-fetch extension properties are provided:
 - `compress`
 - `counter`
 - `agent`
+- `family`
 
 See [options](#fetch-options) for exact meaning of these extensions.
 

--- a/README.md
+++ b/README.md
@@ -216,9 +216,9 @@ The default values are shown after each option key.
 	timeout: 0,         // req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies)
 	compress: true,     // support gzip/deflate content encoding. false to disable
 	size: 0,            // maximum response body size in bytes. 0 to disable
-	agent: null         // http(s).Agent instance, allows custom proxy, certificate etc.
-	lookup: dns.lookup  // custom dns lookup function for socket
-	family: null        // numbers 4 or 6 to limit dns resolution to ip v4 or v6
+	agent: null,        // http(s).Agent instance, allows custom proxy, certificate etc.
+	lookup: dns.lookup, // custom dns lookup function for socket
+	family: null,       // numbers 4 or 6 to limit dns resolution to ip v4 or v6
 	localAddress: null  // local interface to bind to for network connections
 }
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,8 @@ export default function fetch(url, opts) {
 							agent: request.agent,
 							compress: request.compress,
 							method: request.method,
-							body: request.body
+							body: request.body,
+							lookup: request.lookup
 						};
 
 						// HTTP-redirect fetch step 9

--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,9 @@ export default function fetch(url, opts) {
 							compress: request.compress,
 							method: request.method,
 							body: request.body,
-							lookup: request.lookup
+							lookup: request.lookup,
+							family: request.family,
+							localAddress: request.localAddress
 						};
 
 						// HTTP-redirect fetch step 9

--- a/src/request.js
+++ b/src/request.js
@@ -99,6 +99,8 @@ export default class Request {
 		this.counter = init.counter || input.counter || 0;
 		this.agent = init.agent || input.agent;
 		this.lookup = init.lookup || input.lookup;
+		this.family = init.family || input.family;
+		this.localAddress = init.localAddress || input.localAddress;
 	}
 
 	get method() {
@@ -204,6 +206,7 @@ export function getNodeRequestOptions(request) {
 		headers: exportNodeCompatibleHeaders(headers),
 		agent: request.agent,
 		lookup: request.lookup,
-		family: request.family
+		family: request.family,
+		localAddress: request.localAddress
 	});
 }

--- a/src/request.js
+++ b/src/request.js
@@ -98,6 +98,7 @@ export default class Request {
 			input.compress : true;
 		this.counter = init.counter || input.counter || 0;
 		this.agent = init.agent || input.agent;
+		this.lookup = init.lookup || input.lookup;
 	}
 
 	get method() {
@@ -201,6 +202,7 @@ export function getNodeRequestOptions(request) {
 	return Object.assign({}, parsedURL, {
 		method: request.method,
 		headers: exportNodeCompatibleHeaders(headers),
-		agent: request.agent
+		agent: request.agent,
+		lookup: request.lookup
 	});
 }

--- a/src/request.js
+++ b/src/request.js
@@ -203,6 +203,7 @@ export function getNodeRequestOptions(request) {
 		method: request.method,
 		headers: exportNodeCompatibleHeaders(headers),
 		agent: request.agent,
-		lookup: request.lookup
+		lookup: request.lookup,
+		family: request.family
 	});
 }

--- a/src/request.js
+++ b/src/request.js
@@ -11,6 +11,7 @@ import Headers, { exportNodeCompatibleHeaders } from './headers.js';
 import Body, { clone, extractContentType, getTotalBytes } from './body';
 
 const { format: format_url, parse: parse_url } = require('url');
+const dns = require('dns');
 
 const INTERNALS = Symbol('Request internals');
 
@@ -98,9 +99,9 @@ export default class Request {
 			input.compress : true;
 		this.counter = init.counter || input.counter || 0;
 		this.agent = init.agent || input.agent;
-		this.lookup = init.lookup || input.lookup;
-		this.family = init.family || input.family;
-		this.localAddress = init.localAddress || input.localAddress;
+		this.lookup = init.lookup || input.lookup || dns.lookup;
+		this.family = init.family || input.family || null;
+		this.localAddress = init.localAddress || input.localAddress || null;
 	}
 
 	get method() {

--- a/test/test.js
+++ b/test/test.js
@@ -530,6 +530,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should handle DNS-error response', function() {
+		this.timeout(10000);
 		const url = 'http://domain.invalid';
 		return expect(fetch(url)).to.eventually.be.rejected
 			.and.be.an.instanceOf(FetchError)
@@ -1502,7 +1503,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should support https request', function() {
-		this.timeout(5000);
+		this.timeout(10000);
 		const url = 'https://github.com/';
 		const opts = {
 			method: 'HEAD'

--- a/test/test.js
+++ b/test/test.js
@@ -1556,6 +1556,34 @@ describe('node-fetch', () => {
 			expect(called).to.equal(2);
 		});
 	});
+
+	it("should pass the `family` option to the dns lookup", function () {
+		const url = `${base}redirect/301`;
+		const recordedOptions = [];
+		const family = Symbol('family');
+		function lookupSpy(hostname, options, callback) {
+			recordedOptions.push(options);
+			return lookup(hostname, {}, callback);
+		}
+		return fetch(url, { lookup: lookupSpy, family }).then(() => {
+			expect(recordedOptions[0].family).to.equal(family);
+			expect(recordedOptions[1].family).to.equal(family);
+		});
+	});
+
+	it("should succeed with valid values for option `localAddress`", function () {
+		const url = `${base}redirect/301`;
+		return fetch(url, { localAddress: '0.0.0.0' }).then(res => {
+			expect(res.status).to.equal(200);
+			expect(res.ok).to.be.true;
+		});
+	});
+
+	it("should fail with illegal values for option `localAddress`", function () {
+		const url = `${base}hello`;
+		const illegalBind = fetch(url, { localAddress: '1.1.1.1.1' });
+		return expect(illegalBind).to.eventually.be.rejected;
+	});
 });
 
 describe('Headers', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,7 @@ import FormData from 'form-data';
 import stringToArrayBuffer from 'string-to-arraybuffer';
 import URLSearchParams_Polyfill from 'url-search-params';
 import { URL } from 'whatwg-url';
+import { lookup } from 'dns';
 
 const { spawn } = require('child_process');
 const http = require('http');
@@ -1530,6 +1531,30 @@ describe('node-fetch', () => {
 			.and.include({ type: 'system' })
 			.and.have.property('message').that.includes('Could not create Buffer')
 			.and.that.includes('embedded error');
+	});
+
+	it("should call a custom `lookup` function", function() {
+		const url = `${base}hello`;
+		let called = 0;
+		function lookupSpy(hostname, options, callback) {
+			called++;
+			return lookup(hostname, options, callback);
+		}
+		return fetch(url, { lookup: lookupSpy }).then(() => {
+			expect(called).to.equal(1);
+		});
+	});
+
+	it("should use the custom `lookup` function for redirects", function() {
+		const url = `${base}redirect/301`;
+		let called = 0;
+		function lookupSpy(hostname, options, callback) {
+			called++;
+			return lookup(hostname, options, callback);
+		}
+		return fetch(url, { lookup: lookupSpy }).then(() => {
+			expect(called).to.equal(2);
+		});
 	});
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -1569,6 +1569,7 @@ describe('node-fetch', () => {
 		return fetch(url, { lookup: lookupSpy, family }).then(() => {
 			expect(recordedOptions[0].family).to.equal(family);
 			expect(recordedOptions[1].family).to.equal(family);
+			expect(recordedOptions).to.have.length(2);
 		});
 	});
 


### PR DESCRIPTION
This MR unifies #256, #445 and #473.

All options have been added to the documentation and test suite. Support for these options during redirects has been implemented and added to the tests where possible.

Please let me know if You'd like anything changed.