### PR TITLE
support option `lookup`

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ The default values are shown after each option key.
 	timeout: 0,         // req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies)
 	compress: true,     // support gzip/deflate content encoding. false to disable
 	size: 0,            // maximum response body size in bytes. 0 to disable
-	agent: null         // http(s).Agent instance, allows custom proxy, certificate etc.
+	agent: null,        // http(s).Agent instance, allows custom proxy, certificate etc.
+	lookup: dns.lookup  // custom dns lookup function for socket
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,8 @@ export default function fetch(url, opts) {
 							agent: request.agent,
 							compress: request.compress,
 							method: request.method,
-							body: request.body
+							body: request.body,
+							lookup: request.lookup
 						};
 
 						// HTTP-redirect fetch step 9

--- a/src/request.js
+++ b/src/request.js
@@ -98,6 +98,7 @@ export default class Request {
 			input.compress : true;
 		this.counter = init.counter || input.counter || 0;
 		this.agent = init.agent || input.agent;
+		this.lookup = init.lookup || input.lookup;
 	}
 
 	get method() {
@@ -201,6 +202,7 @@ export function getNodeRequestOptions(request) {
 	return Object.assign({}, parsedURL, {
 		method: request.method,
 		headers: exportNodeCompatibleHeaders(headers),
-		agent: request.agent
+		agent: request.agent,
+		lookup: request.lookup
 	});
 }

--- a/src/request.js
+++ b/src/request.js
@@ -11,6 +11,7 @@ import Headers, { exportNodeCompatibleHeaders } from './headers.js';
 import Body, { clone, extractContentType, getTotalBytes } from './body';
 
 const { format: format_url, parse: parse_url } = require('url');
+const dns = require('dns');
 
 const INTERNALS = Symbol('Request internals');
 
@@ -98,7 +99,7 @@ export default class Request {
 			input.compress : true;
 		this.counter = init.counter || input.counter || 0;
 		this.agent = init.agent || input.agent;
-		this.lookup = init.lookup || input.lookup;
+		this.lookup = init.lookup || input.lookup || dns.lookup;
 	}
 
 	get method() {

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,7 @@ import FormData from 'form-data';
 import stringToArrayBuffer from 'string-to-arraybuffer';
 import URLSearchParams_Polyfill from 'url-search-params';
 import { URL } from 'whatwg-url';
+import { lookup } from 'dns';
 
 const { spawn } = require('child_process');
 const http = require('http');
@@ -1530,6 +1531,30 @@ describe('node-fetch', () => {
 			.and.include({ type: 'system' })
 			.and.have.property('message').that.includes('Could not create Buffer')
 			.and.that.includes('embedded error');
+	});
+
+	it("should call a custom `lookup` function", function() {
+		const url = `${base}hello`;
+		let called = 0;
+		function lookupSpy(hostname, options, callback) {
+			called++;
+			return lookup(hostname, options, callback);
+		}
+		return fetch(url, { lookup: lookupSpy }).then(() => {
+			expect(called).to.equal(1);
+		});
+	});
+
+	it("should use the custom `lookup` function for redirects", function() {
+		const url = `${base}redirect/301`;
+		let called = 0;
+		function lookupSpy(hostname, options, callback) {
+			called++;
+			return lookup(hostname, options, callback);
+		}
+		return fetch(url, { lookup: lookupSpy }).then(() => {
+			expect(called).to.equal(2);
+		});
 	});
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -1556,6 +1556,54 @@ describe('node-fetch', () => {
 			expect(called).to.equal(2);
 		});
 	});
+
+	it("should use our custom lookup func even with an agent", function() {
+		const url = `${base}redirect/301`;
+		let called = 0;
+		function lookupSpy(hostname, options, callback) {
+			called++;
+			return lookup(hostname, options, callback);
+		}
+		const agent = http.Agent();
+		return fetch(url, { lookup: lookupSpy, agent }).then(() => {
+			expect(called).to.equal(2);
+		});
+	});
+
+	it("also supports supplying the lookup funtion to the agent", function() {
+		const url = `${base}redirect/301`;
+		let called = 0;
+		function lookupSpy(hostname, options, callback) {
+			called++;
+			return lookup(hostname, options, callback);
+		}
+		const agent = http.Agent({ lookup: lookupSpy });
+		return fetch(url, { agent }).then(() => {
+			expect(called).to.equal(2);
+		});
+	});
+
+	it("prefers the agent's lookup function over ours", function () {
+		const url = `${base}redirect/301`;
+		let lookupsAgent = 0;
+		let lookupsFetch = 0;
+
+		function lookupSpyAgent(hostname, options, callback) {
+			lookupsAgent++;
+			return lookup(hostname, options, callback);
+		}
+
+		function lookupSpyFetch(hostname, options, callback) {
+			lookupsFetch++;
+			return lookup(hostname, options, callback);
+		}
+
+		const agent = http.Agent({ lookup: lookupSpyAgent });
+		return fetch(url, { agent, lookup: lookupSpyFetch }).then(() => {
+			expect(lookupsFetch).to.equal(0);
+			expect(lookupsAgent).to.equal(2);
+		});
+	});
 });
 
 describe('Headers', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -530,6 +530,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should handle DNS-error response', function() {
+		this.timeout(15000);
 		const url = 'http://domain.invalid';
 		return expect(fetch(url)).to.eventually.be.rejected
 			.and.be.an.instanceOf(FetchError)
@@ -1502,7 +1503,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should support https request', function() {
-		this.timeout(5000);
+		this.timeout(10000);
 		const url = 'https://github.com/';
 		const opts = {
 			method: 'HEAD'


### PR DESCRIPTION
Predecessor of #474.

Please excuse the noise, see [discussion in #474](https://github.com/bitinn/node-fetch/pull/474/files/8629d027ace94290ae62859c80f33d1fc845c1eb#r196219236) about why `family` and `localAddress` are no longer part of this. Maybe #256 and #445 should be reopened.

@gr2m: Turns out, even `lookup` can be supplied via an agent. Shall we drop the whole thing? Passing in `lookup` via the agent is good enough for my use case, so feel free to just close.
OTOH, the whole path of agent options ending up in the socket options is really indirect and undocumented as far as I can see. Maybe we should at least mention it in the docs?