### PR TITLE
Fixed html 4 charset detection

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -305,11 +305,7 @@ function convertBody(buffer, headers) {
 
 	// html4
 	if (!res && str) {
-		res = /<meta[\s]+?http-equiv=(['"])content-type\1[\s]+?content=(['"])(.+?)\2/i.exec(str);
-
-		if (res) {
-			res = /charset=(.*)/i.exec(res.pop());
-		}
+		res = /<meta.+?content=["'].+;\s?charset=(.+?)["'\s]/i.exec(str);
 	}
 
 	// xml

--- a/test/server.js
+++ b/test/server.js
@@ -177,10 +177,16 @@ export default class TestServer {
 			res.end(convert('<meta charset="gbk"><div>中文</div>', 'gbk'));
 		}
 
-		if (p === '/encoding/gb2312') {
+		if (p === '/encoding/gb2312/1') {
 			res.statusCode = 200;
 			res.setHeader('Content-Type', 'text/html');
-			res.end(convert('<meta http-equiv="Content-Type" content="text/html; charset=gb2312"><div>中文</div>', 'gb2312'));
+			res.end(convert('<meta http-equiv="Content-Type" content="text/html; charset=gb2312"><div>腾讯首页</div>', 'gb2312'));
+		}
+
+		if (p === '/encoding/gb2312/2') {
+			res.statusCode = 200;
+			res.setHeader('Content-Type', 'text/html');
+			res.end(convert('<meta content="text/html; charset=gb2312 http-equiv="Content-Type""><div>腾讯首页</div>', 'gb2312'));
 		}
 
 		if (p === '/encoding/shift-jis') {

--- a/test/test.js
+++ b/test/test.js
@@ -2269,11 +2269,21 @@ describe('external encoding', () => {
 		});
 
 		it('should support encoding decode, html4 detect', function() {
-			const url = `${base}encoding/gb2312`;
+      		let url
+			
+			url = `${base}encoding/gb2312/1`;
 			return fetch(url).then(res => {
 				expect(res.status).to.equal(200);
 				return res.textConverted().then(result => {
-					expect(result).to.equal('<meta http-equiv="Content-Type" content="text/html; charset=gb2312"><div>中文</div>');
+					expect(result).to.equal('<meta http-equiv="Content-Type" content="text/html; charset=gb2312"><div>腾讯首页</div>');
+				});
+      		});
+
+      		url = `${base}encoding/gb2312/2`;
+			return fetch(url).then(res => {
+				expect(res.status).to.equal(200);
+				return res.textConverted().then(result => {
+					expect(result).to.equal('<meta content="text/html; charset=gb2312" http-equiv="Content-Type"><div>腾讯首页</div>');
 				});
 			});
 		});


### PR DESCRIPTION
Old regex worked for`<meta http-equiv="Content-Type" content="text/html; charset=gb2312">`
but not `<meta content="text/html; charset=gb2312" http-equiv="Content-Type">`

old regex: https://regex101.com/r/y6hyRj/1
new regex: https://regex101.com/r/wb4AFp/1