### PR TITLE
Add "response.redirected" property support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,8 @@ export default function fetch(url, opts) {
 				statusText: res.statusMessage,
 				headers: headers,
 				size: request.size,
-				timeout: request.timeout
+				timeout: request.timeout,
+				redirected: request.redirected
 			};
 
 			// HTTP-network fetch step 12.1.1.3

--- a/src/request.js
+++ b/src/request.js
@@ -115,6 +115,13 @@ export default class Request {
 		return this[INTERNALS].redirect;
 	}
 
+	get redirected() {
+		if (this.counter > 0)
+			return true;
+		else
+			return false;
+	}
+
 	/**
 	 * Clone this request
 	 *

--- a/src/response.js
+++ b/src/response.js
@@ -28,7 +28,8 @@ export default class Response {
 			url: opts.url,
 			status,
 			statusText: opts.statusText || STATUS_CODES[status],
-			headers: new Headers(opts.headers)
+			headers: new Headers(opts.headers),
+			redirected: opts.redirected
 		};
 	}
 
@@ -55,6 +56,10 @@ export default class Response {
 		return this[INTERNALS].headers;
 	}
 
+	get redirected() {
+		return this[INTERNALS].redirected;
+	}
+
 	/**
 	 * Clone this response
 	 *
@@ -66,7 +71,8 @@ export default class Response {
 			status: this.status,
 			statusText: this.statusText,
 			headers: this.headers,
-			ok: this.ok
+			ok: this.ok,
+			redirected: this.redirected
 		});
 
 	}

--- a/test/test.js
+++ b/test/test.js
@@ -278,6 +278,28 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should set redirected response property as true', function() {
+		const url = `${base}redirect/301`;
+		return fetch(url).then(res => {
+			expect(res.url).to.equal(`${base}inspect`);
+			expect(res.status).to.equal(200);
+			expect(res.ok).to.be.true;
+			expect(res.redirected).to.be.true;
+		});
+	});
+
+	it('should set redirected response property as false', function() {
+		const url = `${base}hello`;
+		return fetch(url).then(res => {
+			expect(res.url).to.equal(url);
+			expect(res.ok).to.be.true;
+			expect(res.status).to.equal(200);
+			expect(res.statusText).to.equal('OK');
+			expect(res.redirected).to.be.false;
+		});
+	});
+
+
 	it('should follow POST request redirect code 301 with GET', function() {
 		const url = `${base}redirect/301`;
 		const opts = {

--- a/test/test.js
+++ b/test/test.js
@@ -281,9 +281,6 @@ describe('node-fetch', () => {
 	it('should set redirected response property as true', function() {
 		const url = `${base}redirect/301`;
 		return fetch(url).then(res => {
-			expect(res.url).to.equal(`${base}inspect`);
-			expect(res.status).to.equal(200);
-			expect(res.ok).to.be.true;
 			expect(res.redirected).to.be.true;
 		});
 	});
@@ -291,10 +288,6 @@ describe('node-fetch', () => {
 	it('should set redirected response property as false', function() {
 		const url = `${base}hello`;
 		return fetch(url).then(res => {
-			expect(res.url).to.equal(url);
-			expect(res.ok).to.be.true;
-			expect(res.status).to.equal(200);
-			expect(res.statusText).to.equal('OK');
 			expect(res.redirected).to.be.false;
 		});
 	});


### PR DESCRIPTION
As described in https://developer.mozilla.org/en-US/docs/Web/API/Response/redirected
If any redirection happened, it will be equal to true. Otherwise it will be equal to false.

There is two basic test is the commit to cover this property.