### PR TITLE
Changed how URLSearchParams are handled 

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -410,7 +410,7 @@ export function clone(instance) {
  *
  * @param   Mixed  instance  Response or Request instance
  */
-export function extractContentType(body) {
+function extractContentType(body) {
 	// istanbul ignore if: Currently, because of a guard in Request, body
 	// can never be null. Included here for completeness.
 	if (body === null) {

--- a/src/body.js
+++ b/src/body.js
@@ -26,7 +26,7 @@ const INTERNALS = Symbol('Body internals');
 export default function Body(body, {
 	size = 0,
 	timeout = 0
-} = {}, headers) {
+}, headers) {
 	if (body == null) {
 		// body is undefined or null
 		body = null;

--- a/src/body.js
+++ b/src/body.js
@@ -26,7 +26,7 @@ const INTERNALS = Symbol('Body internals');
 export default function Body(body, {
 	size = 0,
 	timeout = 0
-} = {}) {
+} = {}, headers) {
 	if (body == null) {
 		// body is undefined or null
 		body = null;
@@ -61,6 +61,13 @@ export default function Body(body, {
 		body.on('error', err => {
 			this[INTERNALS].error = new FetchError(`Invalid response body while trying to fetch ${this.url}: ${err.message}`, 'system', err);
 		});
+	}
+
+	if (body != null && !headers.has('Content-Type')) {
+		const contentType = extractContentType(this);
+		if (contentType) {
+			headers.append('Content-Type', contentType);
+		}
 	}
 }
 

--- a/src/body.js
+++ b/src/body.js
@@ -23,10 +23,9 @@ const INTERNALS = Symbol('Body internals');
  * @param   Object  opts  Response options
  * @return  Void
  */
-export default function Body(body, {
-	size = 0,
-	timeout = 0
-}, headers) {
+export default function Body(body, opts, headers) {
+	const { size = 0, timeout = 0 } = opts;
+
 	if (body == null) {
 		// body is undefined or null
 		body = null;

--- a/src/request.js
+++ b/src/request.js
@@ -67,19 +67,12 @@ export default class Request {
 				clone(input) :
 				null;
 
+		const headers = new Headers(init.headers || input.headers || {});
+
 		Body.call(this, inputBody, {
 			timeout: init.timeout || input.timeout || 0,
 			size: init.size || input.size || 0
-		});
-
-		const headers = new Headers(init.headers || input.headers || {});
-
-		if (init.body != null) {
-			const contentType = extractContentType(this);
-			if (contentType !== null && !headers.has('Content-Type')) {
-				headers.append('Content-Type', contentType);
-			}
-		}
+		}, headers);
 
 		this[INTERNALS] = {
 			method,

--- a/src/request.js
+++ b/src/request.js
@@ -9,7 +9,7 @@
 
 import { format as format_url, parse as parse_url } from 'url';
 import Headers, { exportNodeCompatibleHeaders } from './headers.js';
-import Body, { clone, extractContentType, getTotalBytes } from './body';
+import Body, { clone, getTotalBytes } from './body';
 
 const INTERNALS = Symbol('Request internals');
 

--- a/src/response.js
+++ b/src/response.js
@@ -20,7 +20,9 @@ const INTERNALS = Symbol('Response internals');
  */
 export default class Response {
 	constructor(body = null, opts = {}) {
-		Body.call(this, body, opts);
+		const headers = new Headers(opts.headers)
+
+		Body.call(this, body, opts, headers);
 
 		const status = opts.status || 200;
 
@@ -28,7 +30,7 @@ export default class Response {
 			url: opts.url,
 			status,
 			statusText: opts.statusText || STATUS_CODES[status],
-			headers: new Headers(opts.headers)
+			headers
 		};
 	}
 

--- a/test/test.js
+++ b/test/test.js
@@ -1538,7 +1538,7 @@ describe('node-fetch', () => {
 	});
 
 	it('should support arrayBuffer(), blob(), text(), json() and buffer() method in Body constructor', function() {
-		const body = new Body('a=1');
+		const body = new Body('a=1', {}, new Headers());
 		expect(body).to.have.property('arrayBuffer');
 		expect(body).to.have.property('blob');
 		expect(body).to.have.property('text');

--- a/test/test.js
+++ b/test/test.js
@@ -1139,6 +1139,30 @@ describe('node-fetch', () => {
 		expect(req.headers.get('Content-Type')).to.equal('application/x-www-form-urlencoded;charset=UTF-8');
 	});
 
+	itUSP('Reading a body with URLSearchParams should echo back the result', function() {
+		const params = new URLSearchParams();
+		params.append('a','1');
+
+		return new Response(params).text().then(text => {
+			expect(text).to.equal('a=1');
+		});
+	});
+
+	itUSP('mutating URLSearchParams should not have an effect after Request/Response are constructed', function() {
+		const params = new URLSearchParams();
+		const req = new Request(`${base}inspect`, { method: 'POST', body: params })
+
+		params.append('a','1')
+
+		// Couldn't simply use the `new Res(args).text()` or `new Req(args).text()`
+		// since it would fail.
+		return fetch(req).then(res => {
+			return res.json();
+		}).then(res => {
+			expect(res.body).to.equal('');
+		});
+	});
+
 	itUSP('should still recognize URLSearchParams when extended', function() {
 		class CustomSearchParams extends URLSearchParams {}
 		const params = new CustomSearchParams();

--- a/test/test.js
+++ b/test/test.js
@@ -1126,6 +1126,19 @@ describe('node-fetch', () => {
 		});
 	});
 
+	itUSP('constructing a Response with URLSearchParams as body should have a Content-Type', function() {
+		const params = new URLSearchParams();
+		const res = new Response(params);
+		res.headers.get('Content-Type');
+		expect(res.headers.get('Content-Type')).to.equal('application/x-www-form-urlencoded;charset=UTF-8');
+	});
+
+	itUSP('constructing a Request with URLSearchParams as body should have a Content-Type', function() {
+		const params = new URLSearchParams();
+		const req = new Request(base, { method: 'POST', body: params });
+		expect(req.headers.get('Content-Type')).to.equal('application/x-www-form-urlencoded;charset=UTF-8');
+	});
+
 	itUSP('should still recognize URLSearchParams when extended', function() {
 		class CustomSearchParams extends URLSearchParams {}
 		const params = new CustomSearchParams();


### PR DESCRIPTION
I notice there where a problem reading the body of req/res constructed with URLsearchParams since that if condition where missing

https://github.com/bitinn/node-fetch/blob/1d4ab5a0de0df991f92f1f30efd5f4815bbcdb71/src/body.js#L176-L220

Posting it doe works when using fetch. Not sure how but it works 😕

Then i notice that responses didn't set default content-types so I moved the logic of sniffing the content-type into the Body mixin instead

---

So I chose not to not to add a if condition that would allow to read the content of URLSearchParams instead i just converted it to a buffer directly so i could solve 5a62bbf1598665bdf2a5110a51a996edb8e4a490 (mutation of URLSearchParam)