### PR TITLE
Provide global polyfills

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ We suggest you load the module via `require`, pending the stabalizing of es modu
 const fetch = require('node-fetch');
 ```
 
+To polyfill `fetch`, `Headers`, `Request` and `Response` in global scope:
+
+```js
+require('node-fetch/polyfill')
+```
+
 If you are using a Promise library other than native, set it through fetch.Promise:
 ```js
 const Bluebird = require('bluebird');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lib/index.js",
     "lib/index.mjs",
     "lib/index.es.js",
-    "browser.js"
+    "browser.js",
+    "polyfill.js"
   ],
   "engines": {
     "node": "4.x || >=6.0.0"
@@ -28,7 +29,8 @@
   "keywords": [
     "fetch",
     "http",
-    "promise"
+    "promise",
+    "polyfill"
   ],
   "author": "David Frank",
   "license": "MIT",

--- a/polyfill.js
+++ b/polyfill.js
@@ -1,0 +1,5 @@
+global.fetch = require('.')
+
+global.Headers = fetch.Headers
+global.Request = fetch.Request
+global.Response = fetch.Response


### PR DESCRIPTION
Often it is desirable to globally polyfill the `fetch` API in a Node.js server environment, particularly for SSR.

With this PR, you can easily polyfill `fetch`, `Headers`, `Request` and `Response` in global scope:

```js
require('node-fetch/polyfill')
```

Or, with `--experimental-modules`:

```js
import 'node-fetch/polyfill'
```

You can even polyfill a Node.js process via CLI:

```
node -r node-fetch/polyfill server.js
```