### PR TITLE
Remove useless call to `Error` constructor

### DIFF
--- a/src/fetch-error.js
+++ b/src/fetch-error.js
@@ -14,8 +14,6 @@
  * @return  FetchError
  */
 export default function FetchError(message, type, systemError) {
-	Error.call(this, message);
-
 	this.message = message;
 	this.type = type;
 


### PR DESCRIPTION
The function call `Error()` is equivalent to the object creation
expression `new Error()` with the same arguments.

Refs: https://www.ecma-international.org/ecma-262/5.1/#sec-15.11.1