### PR TITLE
avoid callback uncaught error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,11 @@ export default function fetch(url, opts) {
 					case 'manual':
 						// node-fetch-specific step: make manual redirect a bit easier to use by setting the Location header value to the resolved URL.
 						if (locationURL !== null) {
-							headers.set('Location', locationURL);
+							try {
+								headers.set('Location', locationURL);
+							} catch (err) {
+								reject(err)
+							}
 						}
 						break;
 					case 'follow':


### PR DESCRIPTION
the headers.set method could cause the Uncaught TypeError via the validation on headers, however this is not captured inside the event callback, which causes the exit of the whole application.


replicate:

~~~
require('node-fetch')('http://bit.ly/hergivenhairKeeb', {redirect: 'manual'})
~~~

got:

~~~
TypeError: http://xn--www-4m0aa�.hergivenhair.com/?y=MAKEBA112 is not a legal HTTP header value
~~~

I thought about the testing, however it's not trivial to set up the test to return the invalid url, since the node.js serverResponse wouldn't allow invalid head name/value, I can capture a record(via nockBack), but that's kind of overkill maybe?

Thanks.