### PR TITLE
Polyfill self

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,5 +1,15 @@
 "use strict";
 
+function getSelf() {
+  if (typeof self !== 'undefined') return self;
+
+  if (typeof this !== 'undefined') return this;
+  if (typeof global !== 'undefined') return global;
+  if (typeof window !== 'undefined') return window;
+  throw new Error('Failed to access global variable "self".');
+}
+
+;(function(self) {
 module.exports = exports = self.fetch;
 
 // Needed for TypeScript and Webpack.
@@ -8,3 +18,4 @@ exports.default = self.fetch.bind(self);
 exports.Headers = self.Headers;
 exports.Request = self.Request;
 exports.Response = self.Response;
+})(getSelf());


### PR DESCRIPTION
Fix support for environments that doesn't have a `self` global variable, including but not limited to react native.

Alternative implementation to #510
Might or might not help #534 

<img height="400" src="https://user-images.githubusercontent.com/619186/47131610-09f7aa80-d276-11e8-97aa-98d7a0c4785e.png" />

Closes #510 