### PR TITLE
Add support for node-specific options to http(s).request

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -36,6 +36,7 @@ function isRequest(input) {
 export default class Request {
 	constructor(input, init = {}) {
 		let parsedURL;
+		let nodeOptions = init.nodeOptions;
 
 		// normalize input
 		if (!isRequest(input)) {
@@ -51,6 +52,7 @@ export default class Request {
 			input = {};
 		} else {
 			parsedURL = parse_url(input.url);
+			nodeOptions = nodeOptions || input[INTERNALS].nodeOptions;
 		}
 
 		let method = init.method || input.method || 'GET';
@@ -85,7 +87,8 @@ export default class Request {
 			method,
 			redirect: init.redirect || input.redirect || 'follow',
 			headers,
-			parsedURL
+			parsedURL,
+			nodeOptions
 		};
 
 		// node-fetch-only options
@@ -151,6 +154,7 @@ Object.defineProperties(Request.prototype, {
 export function getNodeRequestOptions(request) {
 	const parsedURL = request[INTERNALS].parsedURL;
 	const headers = new Headers(request[INTERNALS].headers);
+	const nodeOptions = request[INTERNALS].nodeOptions || {};
 
 	// fetch step 1.3
 	if (!headers.has('Accept')) {
@@ -197,7 +201,7 @@ export function getNodeRequestOptions(request) {
 	// HTTP-network fetch step 4.2
 	// chunked encoding is handled by Node.js
 
-	return Object.assign({}, parsedURL, {
+	return Object.assign({}, nodeOptions, parsedURL, {
 		method: request.method,
 		headers: exportNodeCompatibleHeaders(headers),
 		agent: request.agent

--- a/test/test.js
+++ b/test/test.js
@@ -229,6 +229,50 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should accept extra node specific options in init', function() {
+		const url = `${base}inspect`;
+		return fetch(url, {
+			nodeOptions: {
+				setHost: false
+			}
+		}).then(res => {
+			return res.json();
+		}).then(res => {
+			expect(res.headers['host']).to.undefined;
+		});
+	});
+
+	it('should accept extra node specific options in request', function() {
+		const url = `${base}inspect`;
+		return fetch(new Request(url, {
+			nodeOptions: {
+				setHost: false
+			}
+		})).then(res => {
+			return res.json();
+		}).then(res => {
+			expect(res.headers['host']).to.undefined;
+		});
+	});
+
+	it('should accept extra node specific options in init overriding request', function() {
+		const url = `${base}inspect`;
+		const origRequest = new Request(url, {
+			nodeOptions: {
+				setHost: true
+			}
+		});
+		return fetch(new Request(origRequest, {
+			nodeOptions: {
+				setHost: false
+			}
+		})).then(res => {
+			return res.json();
+		}).then(res => {
+			expect(res.headers['host']).to.undefined;
+		});
+	});
+
 	it('should follow redirect code 301', function() {
 		const url = `${base}redirect/301`;
 		return fetch(url).then(res => {


### PR DESCRIPTION
This PR will allow users to specify nodeOptions to fetch for use directly in the http(s).request call.  This is especially helpful for https and client certificates, server validation etc.  Syntax is as follows:
```
fetch("http://example.org", { 
  nodeOptions: {
    setHost: false
});
```
For TLS client certificate authentication you could do 
```
fetch("https://example.org", {
  nodeOptions: {
    key: fs.readFileSync('test/fixtures/keys/agent2-key.pem'),
    cert: fs.readFileSync('test/fixtures/keys/agent2-cert.pem')
  }
}
```