### PR TITLE
Add support for AbortSignal to cancel requests

### DIFF
--- a/ERROR-HANDLING.md
+++ b/ERROR-HANDLING.md
@@ -6,7 +6,17 @@ Because `window.fetch` isn't designed to be transparent about the cause of reque
 
 The basics:
 
-- All [operational errors][joyent-guide] are rejected with a [FetchError](https://github.com/bitinn/node-fetch/blob/master/README.md#class-fetcherror). You can handle them all through the promise `catch` clause.
+- A cancelled request is rejected with an [`AbortError`](https://github.com/bitinn/node-fetch/blob/master/README.md#class-aborterror). You can check if the reason for rejection was that the request was aborted by checking the `Error`'s `name` is `AbortError`.
+
+```js
+fetch(url, { signal }).catch(err => {
+  if (err.name === 'AbortError') {
+    // request was aborted
+  }
+})
+```
+
+- All [operational errors][joyent-guide] *other than aborted requests* are rejected with a [FetchError](https://github.com/bitinn/node-fetch/blob/master/README.md#class-fetcherror). You can handle them all through the promise `catch` clause.
 
 - All errors come with an `err.message` detailing the cause of errors.
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
   },
   "homepage": "https://github.com/bitinn/node-fetch",
   "devDependencies": {
+    "abort-controller": "^1.0.2",
+    "abortcontroller-polyfill": "^1.1.9",
     "babel-core": "^6.26.0",
     "babel-plugin-istanbul": "^4.1.5",
     "babel-preset-env": "^1.6.1",

--- a/src/abort-error.js
+++ b/src/abort-error.js
@@ -1,0 +1,25 @@
+/**
+ * abort-error.js
+ *
+ * AbortError interface for cancelled requests
+ */
+
+/**
+ * Create AbortError instance
+ *
+ * @param   String      message      Error message for human
+ * @return  AbortError
+ */
+export default function AbortError(message) {
+	Error.call(this, message);
+
+	this.type = 'aborted';
+	this.message = message;
+
+	// hide custom error implementation details from end-users
+	Error.captureStackTrace(this, this.constructor);
+}
+
+AbortError.prototype = Object.create(Error.prototype);
+AbortError.prototype.constructor = AbortError;
+AbortError.prototype.name = 'AbortError';

--- a/test/server.js
+++ b/test/server.js
@@ -269,6 +269,20 @@ export default class TestServer {
 			res.end();
 		}
 
+		if (p === '/redirect/slow') {
+			res.statusCode = 301;
+			res.setHeader('Location', '/redirect/301');
+			setTimeout(function() {
+				res.end();
+			}, 1000);
+		}
+
+		if (p === '/redirect/slow-stream') {
+			res.statusCode = 301;
+			res.setHeader('Location', '/slow');
+			res.end();
+		}
+
 		if (p === '/error/400') {
 			res.statusCode = 400;
 			res.setHeader('Content-Type', 'text/plain');


### PR DESCRIPTION
Whether or not you actually deprecate timeout should probably be a separate issue (#523) - but I think at the very least there should be support for `AbortSignal` here.

Let me know if you would need any changes to make this happen!