### PR TITLE
How to  fixed html 4 charset detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ node_modules
 
 # Coveralls token files
 .coveralls.yml
+
+## ignore some files from 2.x branch
+
+.nyc_output
+lib/index.js
+lib/index.es.js

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ node_modules
 .nyc_output
 lib/index.js
 lib/index.es.js
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,10 @@ node_js:
   - "0.10"
   - "0.12"
   - "node"
+env:
+  - FORMDATA_VERSION=1.0.0
+  - FORMDATA_VERSION=2.1.0
+before_script:
+  - 'if [ "$FORMDATA_VERSION" ]; then npm install form-data@^$FORMDATA_VERSION; fi'
 before_install: npm install -g npm
 script: npm run coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ env:
   - FORMDATA_VERSION=2.1.0
 before_script:
   - 'if [ "$FORMDATA_VERSION" ]; then npm install form-data@^$FORMDATA_VERSION; fi'
-before_install: if [[ $TRAVIS_NODE_VERSION <= 1 ]]; then npm install -g npm@1.4.28; fi
+before_install: if [[ `npm -v` < 3 ]]; then npm install -g npm@1.4.28; fi
 script: npm run coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ env:
   - FORMDATA_VERSION=2.1.0
 before_script:
   - 'if [ "$FORMDATA_VERSION" ]; then npm install form-data@^$FORMDATA_VERSION; fi'
-before_install: npm install -g npm
+before_install: npm install -g npm@1.4.28
 script: npm run coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ env:
   - FORMDATA_VERSION=2.1.0
 before_script:
   - 'if [ "$FORMDATA_VERSION" ]; then npm install form-data@^$FORMDATA_VERSION; fi'
-before_install: npm install -g npm@1.4.28
+before_install: if [[ $TRAVIS_NODE_VERSION <= 1 ]]; then npm install -g npm@1.4.28; fi
 script: npm run coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Changelog
 
 (Note: `1.x` will only have backported bugfix releases beyond `1.7.0`)
 
+## v1.7.2
+
+- Fix: when using node-fetch with test framework such as `jest`, `instanceof` check could fail in `Headers` class. This is causing some header values, such as `set-cookie`, to be dropped incorrectly.
+
 ## v1.7.1
 
 - Fix: close local test server properly under Node 8.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ Changelog
 
 # 1.x release
 
-## v1.7.0
+(Note: `1.x` will only have backported bugfix releases beyond `1.7.0`)
 
-(Note: this is a maintenance release, `1.x` will only have backported bugfix beyond this release.)
+## v1.7.1
+
+- Fix: close local test server properly under Node 8.
+
+## v1.7.0
 
 - Fix: revert change in `v1.6.2` where 204 no-content response is handled with a special case, this conflicts with browser Fetch implementation (as browsers always throw when res.json() parses an empty string). Since this is an operational error, it's wrapped in a `FetchError` for easier error handling.
 - Fix: move code coverage tool to codecov platform and update travis config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Changelog
 
 (Note: `1.x` will only have backported bugfix releases beyond `1.7.0`)
 
+## v1.7.3
+
+- Enhance: `FetchError` now gives a correct trace stack (backport from v2.x relese).
+
 ## v1.7.2
 
 - Fix: when using node-fetch with test framework such as `jest`, `instanceof` check could fail in `Headers` class. This is causing some header values, such as `set-cookie`, to be dropped incorrectly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 
 ## v1.6.2
 
+- Enhance: minor document update
 - Fix: response.json() returns empty object on 204 no-content response instead of throwing a syntax error
 
 ## v1.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Changelog
 
 # 1.x release
 
+## v1.6.3
+
+- Enhance: error handling document to explain `FetchError` design
+- Fix: support `form-data` 2.x releases (requires `form-data` >= 2.1.0)
+
 ## v1.6.2
 
 - Enhance: minor document update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Changelog
 
 # 1.x release
 
+## v1.7.0
+
+(Note: this is a maintenance release, `1.x` will only have backported bugfix beyond this release.)
+
+- Fix: revert change in `v1.6.2` where 204 no-content response is handled with a special case, this conflicts with browser Fetch implementation (as browsers always throw when res.json() parses an empty string). Since this is an operational error, it's wrapped in a `FetchError` for easier error handling.
+
 ## v1.6.3
 
 - Enhance: error handling document to explain `FetchError` design

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 (Note: this is a maintenance release, `1.x` will only have backported bugfix beyond this release.)
 
 - Fix: revert change in `v1.6.2` where 204 no-content response is handled with a special case, this conflicts with browser Fetch implementation (as browsers always throw when res.json() parses an empty string). Since this is an operational error, it's wrapped in a `FetchError` for easier error handling.
+- Fix: move code coverage tool to codecov platform and update travis config
 
 ## v1.6.3
 

--- a/ERROR-HANDLING.md
+++ b/ERROR-HANDLING.md
@@ -1,0 +1,21 @@
+
+Error handling with node-fetch
+==============================
+
+Because `window.fetch` isn't designed to transparent about the cause of request errors, we have to come up with our own solutions.
+
+The basics:
+
+- All [operational errors](https://www.joyent.com/node-js/production/design/errors) are rejected as [FetchError](https://github.com/bitinn/node-fetch/blob/master/lib/fetch-error.js), you can handle them all through promise `catch` clause.
+
+- All errors comes with `err.message` detailing the cause of errors.
+
+- All errors originated from `node-fetch` are marked with custom `err.type`.
+
+- All errors originated from Node.js core are marked with `err.type = system`, and contains addition `err.code` and `err.errno` for error handling, they are alias to error codes thrown by Node.js core.
+
+- [Programmer errors](https://www.joyent.com/node-js/production/design/errors) are either thrown as soon as possible, or rejected with default `Error` with `err.message` for ease of troubleshooting.
+
+List of error types:
+
+- Because we maintain 100% coverage, see [test.js](https://github.com/bitinn/node-fetch/blob/master/test/test.js) for a full list of custom `FetchError` types, as well as some of the common errors from Node.js

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ node-fetch
 
 [![npm version][npm-image]][npm-url]
 [![build status][travis-image]][travis-url]
-[![coverage status][coveralls-image]][coveralls-url]
+[![coverage status][codecov-image]][codecov-url]
 
 A light-weight module that brings `window.fetch` to Node.js
 
@@ -206,5 +206,5 @@ Thanks to [github/fetch](https://github.com/github/fetch) for providing a solid 
 [npm-url]: https://www.npmjs.com/package/node-fetch
 [travis-image]: https://img.shields.io/travis/bitinn/node-fetch.svg?style=flat-square
 [travis-url]: https://travis-ci.org/bitinn/node-fetch
-[coveralls-image]: https://img.shields.io/coveralls/bitinn/node-fetch.svg?style=flat-square
-[coveralls-url]: https://coveralls.io/r/bitinn/node-fetch
+[codecov-image]: https://img.shields.io/codecov/c/github/bitinn/node-fetch.svg?style=flat-square
+[codecov-url]: https://codecov.io/gh/bitinn/node-fetch

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See Matt Andrews' [isomorphic-fetch](https://github.com/matthew-andrews/isomorph
 - Use native promise, but allow substituting it with [insert your favorite promise library].
 - Use native stream for body, on both request and response.
 - Decode content encoding (gzip/deflate) properly, and convert string output (such as `res.text()` and `res.json()`) to UTF-8 automatically.
-- Useful extensions such as timeout, redirect limit, response size limit, explicit errors for troubleshooting.
+- Useful extensions such as timeout, redirect limit, response size limit, [explicit errors](https://github.com/bitinn/node-fetch/blob/master/ERROR-HANDLING.md) for troubleshooting.
 
 
 # Difference from client-side fetch

--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ function Fetch(url, opts) {
 			req.end();
 		} else if (options.body instanceof Buffer) {
 			req.write(options.body);
-			req.end()
+			req.end();
 		} else if (typeof options.body === 'object' && options.body.pipe) {
 			options.body.pipe(req);
 		} else if (typeof options.body === 'object') {

--- a/index.js
+++ b/index.js
@@ -94,8 +94,14 @@ function Fetch(url, opts) {
 			if (typeof options.body === 'string') {
 				headers.set('content-length', Buffer.byteLength(options.body));
 			// detect form data input from form-data module, this hack avoid the need to add content-length header manually
-			} else if (options.body && typeof options.body.getLengthSync === 'function' && options.body._lengthRetrievers.length == 0) {
-				headers.set('content-length', options.body.getLengthSync().toString());
+			} else if (options.body && typeof options.body.getLengthSync === 'function') {
+				// for form-data 1.x
+				if (options.body._lengthRetrievers && options.body._lengthRetrievers.length == 0) {
+					headers.set('content-length', options.body.getLengthSync().toString());
+				// for form-data 2.x
+				} else if (options.body.hasKnownLength && options.body.hasKnownLength()) {
+					headers.set('content-length', options.body.getLengthSync().toString());
+				}
 			// this is only necessary for older nodejs releases (before iojs merge)
 			} else if (options.body === undefined || options.body === null) {
 				headers.set('content-length', '0');

--- a/lib/body.js
+++ b/lib/body.js
@@ -39,13 +39,14 @@ function Body(body, opts) {
  */
 Body.prototype.json = function() {
 
-	// for 204 No Content response, buffer will be empty, parsing it will throw error
-	if (this.status === 204) {
-		return Body.Promise.resolve({});
-	}
+	var self = this;
 
 	return this._decode().then(function(buffer) {
-		return JSON.parse(buffer.toString());
+		try {
+			return JSON.parse(buffer.toString());
+		} catch (err) {
+			return Body.Promise.reject(new FetchError('invalid json response body at ' + self.url + ' reason: ' + err.message, 'invalid-json'));
+		}
 	});
 
 };

--- a/lib/fetch-error.js
+++ b/lib/fetch-error.js
@@ -17,9 +17,6 @@ module.exports = FetchError;
  */
 function FetchError(message, type, systemError) {
 
-	// hide custom error implementation details from end-users
-	Error.captureStackTrace(this, this.constructor);
-
 	this.name = this.constructor.name;
 	this.message = message;
 	this.type = type;
@@ -29,6 +26,8 @@ function FetchError(message, type, systemError) {
 		this.code = this.errno = systemError.code;
 	}
 
+	// hide custom error implementation details from end-users
+	Error.captureStackTrace(this, this.constructor);
 }
 
 require('util').inherits(FetchError, Error);

--- a/lib/headers.js
+++ b/lib/headers.js
@@ -35,7 +35,7 @@ function Headers(headers) {
 		} else if (typeof headers[prop] === 'number' && !isNaN(headers[prop])) {
 			this.set(prop, headers[prop].toString());
 
-		} else if (headers[prop] instanceof Array) {
+		} else if (Array.isArray(headers[prop])) {
 			headers[prop].forEach(function(item) {
 				self.append(prop, item.toString());
 			});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-fetch",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A light-weight module that brings window.fetch to node.js and io.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-fetch",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "A light-weight module that brings window.fetch to node.js and io.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-fetch",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "A light-weight module that brings window.fetch to node.js and io.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
     "coveralls": "^2.11.2",
-    "form-data": "^1.0.0-rc1",
+    "form-data": "^1.0.0",
     "istanbul": "^0.4.2",
     "mocha": "^2.1.0",
     "parted": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-fetch",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A light-weight module that brings window.fetch to node.js and io.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
     "coveralls": "^2.11.2",
-    "form-data": "^1.0.0",
+    "form-data": ">=1.0.0",
     "istanbul": "^0.4.2",
     "mocha": "^2.1.0",
     "parted": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-fetch",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "A light-weight module that brings window.fetch to node.js and io.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-fetch",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "A light-weight module that brings window.fetch to node.js and io.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "mocha test/test.js",
     "report": "istanbul cover _mocha -- -R spec test/test.js",
-    "coverage": "istanbul cover _mocha --report lcovonly -- -R spec test/test.js && cat ./coverage/lcov.info | coveralls"
+    "coverage": "istanbul cover _mocha --report lcovonly -- -R spec test/test.js && codecov"
   },
   "repository": {
     "type": "git",
@@ -27,7 +27,7 @@
     "bluebird": "^3.3.4",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
-    "coveralls": "^2.11.2",
+    "codecov": "^1.0.1",
     "form-data": ">=1.0.0",
     "istanbul": "^0.4.2",
     "mocha": "^2.1.0",

--- a/test/server.js
+++ b/test/server.js
@@ -12,6 +12,9 @@ function TestServer() {
 	this.server = http.createServer(this.router);
 	this.port = 30001;
 	this.hostname = 'localhost';
+	// node 8 default keepalive timeout is 5000ms
+	// make it shorter here as we want to close server quickly at the end of tests
+	this.server.keepAliveTimeout = 1000;
 	this.server.on('error', function(err) {
 		console.log(err.stack);
 	});

--- a/test/test.js
+++ b/test/test.js
@@ -441,13 +441,10 @@ describe('node-fetch', function() {
 		});
 	});
 
-	it('should return empty object on no-content response', function() {
+	it('should throw on no-content json response', function() {
 		url = base + '/no-content';
 		return fetch(url).then(function(res) {
-			return res.json().then(function(result) {
-				expect(result).to.be.an('object');
-				expect(result).to.be.empty;
-			});
+			return expect(res.json()).to.eventually.be.rejectedWith(FetchError);
 		});
 	});
 

--- a/test/test.js
+++ b/test/test.js
@@ -1458,7 +1458,7 @@ describe('node-fetch', function() {
 		expect(body).to.have.property('buffer');
 	});
 
-	it('should create custom FetchError', function() {
+	it('should create custom FetchError', function funcName() {
 		var systemError = new Error('system');
 		systemError.code = 'ESOMEERROR';
 
@@ -1470,6 +1470,8 @@ describe('node-fetch', function() {
 		expect(err.type).to.equal('test-error');
 		expect(err.code).to.equal('ESOMEERROR');
 		expect(err.errno).to.equal('ESOMEERROR');
+		expect(err.stack).to.include('funcName');
+		expect(err.stack.split('\n')[0]).to.equal(err.name + ': ' + err.message);
 	});
 
 	it('should support https request', function() {


### PR DESCRIPTION
Thx for this, I am putting this on hold for now, as textConverted() is really a legacy API that's created to be backward compatible with node-fetch v1.

It's not a part of Fetch Spec and ideally we want to phase out this API and create a simple module that takes res.body and output exactly the same UTF-8 plain text.

If you ended up making such a module please let us know.