### PR TITLE
Workaround lack of self in react-native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Changelog
 
 # 2.x release
 
+## master
+
+- Fix: update `browser.js` to support react-native, where `self` isn't available.
+
 ## v2.2.1
 
 - Fix: `compress` flag shouldn't overwrite existing `Accept-Encoding` header.

--- a/browser.js
+++ b/browser.js
@@ -1,10 +1,23 @@
 "use strict";
 
-module.exports = exports = self.fetch;
+// ref: https://github.com/tc39/proposal-global
+var getGlobal = function () {
+	// the only reliable means to get the global object is
+	// `Function('return this')()`
+	// However, this causes CSP violations in Chrome apps.
+	if (typeof self !== 'undefined') { return self; }
+	if (typeof window !== 'undefined') { return window; }
+	if (typeof global !== 'undefined') { return global; }
+	throw new Error('unable to locate global object');
+}
+
+var global = getGlobal();
+
+module.exports = exports = global.fetch;
 
 // Needed for TypeScript and Webpack.
-exports.default = self.fetch.bind(self);
+exports.default = global.fetch.bind(global);
 
-exports.Headers = self.Headers;
-exports.Request = self.Request;
-exports.Response = self.Response;
+exports.Headers = global.Headers;
+exports.Request = global.Request;
+exports.Response = global.Response;


### PR DESCRIPTION
By trying to guess available global.

- And no, we are not going to fix cases where `global`, `self` or `window` isn't actually global.

- And no, we are not going to check `this` is global, I know v8/jsc shell might need it, but it was not our goal to make `node-fetch` *just work* there.

People, you have to deal with your own mistakes here.

ref: https://github.com/tc39/proposal-global