### PR TITLE
Pass localAddress to node request options

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -123,6 +123,7 @@ export default class Request {
 			input.compress : true;
 		this.counter = init.counter || input.counter || 0;
 		this.agent = init.agent || input.agent;
+		this.localAddress = init.localAddress || input.localAddress;
 	}
 
 	get method() {
@@ -240,6 +241,7 @@ export function getNodeRequestOptions(request) {
 	return Object.assign({}, parsedURL, {
 		method: request.method,
 		headers: exportNodeCompatibleHeaders(headers),
-		agent: request.agent
+		agent: request.agent,
+		localAddress: request.localAddress
 	});
 }


### PR DESCRIPTION
This is the `localAddress` part of #256. Happy for suggestions on how to expose this in order to make it testable.