### PR TITLE
Headers should not accept empty field name

### DIFF
--- a/src/headers.js
+++ b/src/headers.js
@@ -10,7 +10,7 @@ const invalidHeaderCharRegex = /[^\t\x20-\x7e\x80-\xff]/;
 
 function validateName(name) {
 	name = `${name}`;
-	if (invalidTokenRegex.test(name)) {
+	if (invalidTokenRegex.test(name) || name === '') {
 		throw new TypeError(`${name} is not a legal HTTP header name`);
 	}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -2008,6 +2008,8 @@ describe('Headers', function () {
 		expect(() => headers.get('Hé-y'))          .to.throw(TypeError);
 		expect(() => headers.has('Hé-y'))          .to.throw(TypeError);
 		expect(() => headers.set('Hé-y', 'ok'))    .to.throw(TypeError);
+		// should reject empty header
+		expect(() => headers.append('', 'ok'))     .to.throw(TypeError);
 
 		// 'o k' is valid value but invalid name
 		new Headers({ 'He-y': 'o k' });


### PR DESCRIPTION
Related: https://github.com/github/fetch/pull/684 , https://github.com/denoland/deno/pull/1427

From https://tools.ietf.org/html/rfc7230#section-3.2,
```
header-field   = field-name ":" OWS field-value OWS

field-name     = token
```
and
```
token = 1*tchar
```

In Chrome, appending a header with empty field name throws and error:
<img width="345" alt="screen shot 2018-12-29 at 12 28 53 am" src="https://user-images.githubusercontent.com/15007517/50535636-d43a3200-0b00-11e9-861b-f0b51dd5ade1.png">
