### PR TITLE
Add code to support TLS client certificates in 1.x branch; bump to v1.7.4

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -61,6 +61,13 @@ function Request(input, init) {
 	this.port = url_parsed.port;
 	this.path = url_parsed.path;
 	this.auth = url_parsed.auth;
+
+	// TLS certificate info
+	this.ca = init.ca
+	this.cert = init.cert
+	this.checkServerIdentity = init.checkServerIdentity
+	this.key = init.key
+	this.servername = init.servername
 }
 
 Request.prototype = Object.create(Body.prototype);

--- a/lib/request.js
+++ b/lib/request.js
@@ -62,12 +62,22 @@ function Request(input, init) {
 	this.path = url_parsed.path;
 	this.auth = url_parsed.auth;
 
-	// TLS certificate info
-	this.ca = init.ca
-	this.cert = init.cert
-	this.checkServerIdentity = init.checkServerIdentity
-	this.key = init.key
-	this.servername = init.servername
+	// Copy over any available TLS certificate info
+	if (init.ca) {
+		this.ca = init.ca
+	}
+	if (init.cert) {
+		this.cert = init.cert
+	}
+	if (init.key) {
+		this.key = init.key
+	}
+	if (init.servername) {
+		this.servername = init.servername
+	}
+	if (init.checkServerIdentity) {
+		this.checkServerIdentity = init.checkServerIdentity
+	}
 }
 
 Request.prototype = Object.create(Body.prototype);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-fetch",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "A light-weight module that brings window.fetch to node.js and io.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-fetch",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "A light-weight module that brings window.fetch to node.js and io.js",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -1478,7 +1478,9 @@ describe('node-fetch', function() {
 		this.timeout(5000);
 		url = 'https://github.com/';
 		opts = {
-			method: 'HEAD'
+			method: 'HEAD',
+			servername: 'github.com',
+			checkServerIdentity: (host,cert) => undefined
 		};
 		return fetch(url, opts).then(function(res) {
 			expect(res.status).to.equal(200);

--- a/test/test.js
+++ b/test/test.js
@@ -1480,7 +1480,7 @@ describe('node-fetch', function() {
 		opts = {
 			method: 'HEAD',
 			servername: 'github.com',
-			checkServerIdentity: (host,cert) => undefined
+			checkServerIdentity: (host,cert) => { return undefined }
 		};
 		return fetch(url, opts).then(function(res) {
 			expect(res.status).to.equal(200);

--- a/test/test.js
+++ b/test/test.js
@@ -1480,7 +1480,7 @@ describe('node-fetch', function() {
 		opts = {
 			method: 'HEAD',
 			servername: 'github.com',
-			checkServerIdentity: (host,cert) => { return undefined }
+			checkServerIdentity: function(host,cert) { return undefined }
 		};
 		return fetch(url, opts).then(function(res) {
 			expect(res.status).to.equal(200);


### PR DESCRIPTION
I need to be able to include TLS info with the request, so added a few lines to copy the info from the init object into the Request when it is created.