### PR TITLE
fix #571 (OnRedirect Hook) dist the hook for redirects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,7 @@ export default function fetch(url, opts) {
 				const location = headers.get('Location');
 
 				// HTTP fetch step 5.3
-				const locationURL = location === null ? null : resolve_url(request.url, location);
+				let locationURL = location === null ? null : resolve_url(request.url, location);
 
 				// HTTP fetch step 5.5
 				switch (request.redirect) {
@@ -144,7 +144,7 @@ export default function fetch(url, opts) {
 
 						// HTTP-redirect fetch step 6 (counter increment)
 						// Create a new Request object.
-						const requestOpts = {
+						let requestOpts = {
 							headers: new Headers(request.headers),
 							follow: request.follow,
 							counter: request.counter + 1,
@@ -153,6 +153,7 @@ export default function fetch(url, opts) {
 							method: request.method,
 							body: request.body,
 							signal: request.signal,
+							onRedirect: request.onRedirect
 						};
 
 						// HTTP-redirect fetch step 9
@@ -167,6 +168,18 @@ export default function fetch(url, opts) {
 							requestOpts.method = 'GET';
 							requestOpts.body = undefined;
 							requestOpts.headers.delete('content-length');
+						}
+
+						if (request.onRedirect) {
+							let overridden = request.onRedirect({ 
+								prev: request.url,
+								url: locationURL, 
+								opts: requestOpts 
+							});
+							if (overridden) {
+								locationURL = overridden.url || locationURL;
+								requestOpts = overridden.opts || requestOpts;
+							}
 						}
 
 						// HTTP-redirect fetch step 15

--- a/src/request.js
+++ b/src/request.js
@@ -123,6 +123,7 @@ export default class Request {
 			input.compress : true;
 		this.counter = init.counter || input.counter || 0;
 		this.agent = init.agent || input.agent;
+		this.onRedirect = init.onRedirect || input.onRedirect;
 	}
 
 	get method() {

--- a/test/test.js
+++ b/test/test.js
@@ -242,6 +242,19 @@ describe('node-fetch', () => {
 		});
 	});
 
+	it('should call hook on redirect', function() {
+		const url = `${base}redirect/301`;
+		const onRedirect = (data) => {
+			expect(data.prev).to.be.equal(url);
+			expect(data.url).to.be.equal(`${base}inspect`);
+			isHookCalled = true;
+		};
+		let isHookCalled = false;
+		return fetch(url, { onRedirect }).then(res => {
+			expect(isHookCalled).to.be.true;
+		});
+	});
+
 	it('should follow redirect code 302', function() {
 		const url = `${base}redirect/302`;
 		return fetch(url).then(res => {


### PR DESCRIPTION
Adds the hook on redirects, so that the consumer can change some options or url. 
In particular, the #571 issue can be solved by the developer, by passing the appropriate agent.