### PR TITLE
Improve performance on buffer concatenation

### DIFF
--- a/src/blob.js
+++ b/src/blob.js
@@ -12,6 +12,7 @@ export default class Blob {
 		const options = arguments[1];
 
 		const buffers = [];
+		buffers._size = 0;
 
 		if (blobParts) {
 			const a = blobParts;
@@ -30,11 +31,12 @@ export default class Blob {
 				} else {
 					buffer = Buffer.from(typeof element === 'string' ? element : String(element));
 				}
+				buffers._size += buffer.length;
 				buffers.push(buffer);
 			}
 		}
 
-		this[BUFFER] = Buffer.concat(buffers);
+		this[BUFFER] = Buffer.concat(buffers, buffers._size);
 
 		let type = options && options.type !== undefined && String(options.type).toLowerCase();
 		if (type && !/[^\u0020-\u007E]/.test(type)) {

--- a/src/body.js
+++ b/src/body.js
@@ -258,7 +258,7 @@ function consumeBody() {
 			clearTimeout(resTimeout);
 
 			try {
-				resolve(Buffer.concat(accum));
+				resolve(Buffer.concat(accum, accumBytes));
 			} catch (err) {
 				// handle streams that have accumulated too much data (issue #414)
 				reject(new FetchError(`Could not create Buffer from response body for ${this.url}: ${err.message}`, 'system', err));


### PR DESCRIPTION
Buffer.concat with a total length argument will ignore recalculate buffers
length in Buffer.concat, it will improve performance.