### PR TITLE
Add formdata-node support

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,25 @@ fetch('https://httpbin.org/post', options)
     .then(json => console.log(json));
 ```
 
+node-fetch support [formdata-node](https://github.com/octet-stream/form-data) as an alternative:
+
+```js
+import FormData from 'formdata-node';
+
+const form = new FormData();
+
+form.set('greeting', 'Hello, world!');
+
+const options = {
+    method: 'POST',
+    body: form
+};
+
+fetch('https://httpbin.org/post', options)
+    .then(res => res.json())
+    .then(json => console.log(json));
+```
+
 #### Request cancellation with AbortSignal
 
 > NOTE: You may only cancel streamed requests on Node >= v8.0.0

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "codecov": "^3.0.0",
     "cross-env": "^5.1.3",
     "form-data": "^2.3.1",
+    "formdata-node": "^1.5.2",
     "is-builtin-module": "^1.0.0",
     "mocha": "^5.0.0",
     "nyc": "11.9.0",

--- a/src/body.js
+++ b/src/body.js
@@ -5,7 +5,7 @@
  * Body interface provides common methods for Request and Response
  */
 
-import Stream from 'stream';
+import Stream, { Readable } from 'stream';
 
 import Blob, { BUFFER } from './blob.js';
 import FetchError from './fetch-error.js';
@@ -50,6 +50,9 @@ export default function Body(body, {
 		body = Buffer.from(body.buffer, body.byteOffset, body.byteLength);
 	} else if (body instanceof Stream) {
 		// body is stream
+	} else if (body.stream instanceof Readable && typeof body.boundary === 'string') {
+		// body is an instance of formdata-node
+		body = body.stream
 	} else {
 		// none of the above
 		// coerce to string then buffer
@@ -422,6 +425,8 @@ export function extractContentType(body) {
 	} else if (typeof body.getBoundary === 'function') {
 		// detect form data input from form-data module
 		return `multipart/form-data;boundary=${body.getBoundary()}`;
+	} else if (body.stream instanceof Readable && typeof body.boundary === "string") {
+		return `multipart/form-data;boundary=${body.boundary}`;
 	} else if (body instanceof Stream) {
 		// body is stream
 		// can't really do much about this

--- a/src/body.js
+++ b/src/body.js
@@ -5,7 +5,7 @@
  * Body interface provides common methods for Request and Response
  */
 
-import Stream, { Readable } from 'stream';
+import Stream from 'stream';
 
 import Blob, { BUFFER } from './blob.js';
 import FetchError from './fetch-error.js';
@@ -50,7 +50,7 @@ export default function Body(body, {
 		body = Buffer.from(body.buffer, body.byteOffset, body.byteLength);
 	} else if (body instanceof Stream) {
 		// body is stream
-	} else if (body.stream instanceof Readable && typeof body.boundary === 'string') {
+	} else if (body.stream instanceof Stream.Readable && typeof body.boundary === 'string') {
 		// body is an instance of formdata-node
 		body = body.stream
 	} else {
@@ -425,7 +425,7 @@ export function extractContentType(body) {
 	} else if (typeof body.getBoundary === 'function') {
 		// detect form data input from form-data module
 		return `multipart/form-data;boundary=${body.getBoundary()}`;
-	} else if (body.stream instanceof Readable && typeof body.boundary === 'string') {
+	} else if (body.stream instanceof Stream.Readable && typeof body.boundary === 'string') {
 		return `multipart/form-data;boundary=${body.boundary}`;
 	} else if (body instanceof Stream) {
 		// body is stream

--- a/src/body.js
+++ b/src/body.js
@@ -425,7 +425,7 @@ export function extractContentType(body) {
 	} else if (typeof body.getBoundary === 'function') {
 		// detect form data input from form-data module
 		return `multipart/form-data;boundary=${body.getBoundary()}`;
-	} else if (body.stream instanceof Readable && typeof body.boundary === "string") {
+	} else if (body.stream instanceof Readable && typeof body.boundary === 'string') {
 		return `multipart/form-data;boundary=${body.boundary}`;
 	} else if (body instanceof Stream) {
 		// body is stream

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,7 @@ import chaiString from 'chai-string';
 import then from 'promise';
 import resumer from 'resumer';
 import FormData from 'form-data';
+import FormDataNode from "formdata-node";
 import stringToArrayBuffer from 'string-to-arraybuffer';
 import URLSearchParams_Polyfill from 'url-search-params';
 import { URL } from 'whatwg-url';
@@ -1346,6 +1347,28 @@ describe('node-fetch', () => {
 			expect(res.body).to.equal('a=1');
 		});
 	});
+
+  it('should support formdata-node as POST body', function() {
+    const form = new FormDataNode();
+
+    form.set('field', "some text");
+    form.set('file', fs.createReadStream(path.join(__dirname, 'dummy.txt')));
+
+    const url = `${base}multipart`;
+    const opts = {
+      method: 'POST',
+      body: form
+    };
+
+    return fetch(url, opts)
+      .then(res => res.json())
+      .then(res => {
+        expect(res.method).to.equal('POST');
+        expect(res.headers['content-type']).to.equal(`multipart/form-data;boundary=${form.boundary}`);
+        expect(res.body).to.contain('field=');
+        expect(res.body).to.contain('file=');
+      });
+  });
 
 	it('should allow POST request with object body', function() {
 		const url = `${base}inspect`;


### PR DESCRIPTION
This pull request brings support of the [formdata-node](https://github.com/octet-stream/form-data) package in request body.

Notes on the PR:
- Differences between form-data and formdata-node: https://github.com/octet-stream/form-data/issues/1
- Content-Length is not supported for formdata-node because the package only have asynchronous method for that: [`FormData#getComputedLength()`](https://github.com/octet-stream/form-data#getcomputedlength---promisenumber)
- formdata-node requires at least [Node 8](https://github.com/octet-stream/form-data/blob/a663fd21f3c13a600186e6c4d742404cc5f46ccd/package.json#L16), but tests seem to work on Node 6 as well.