### PR TITLE
build: start testing against node.js 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "12"
   - "node"
 env:
   - FORMDATA_VERSION=1.0.0


### PR DESCRIPTION
This adds Node.js 12.0.0 to the Travis testing matrix.