### PR TITLE
chore(deps): address deprecated url-search-params package

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "homepage": "https://github.com/bitinn/node-fetch",
   "devDependencies": {
+    "@ungap/url-search-params": "^0.1.2",
     "abort-controller": "^1.1.0",
     "abortcontroller-polyfill": "^1.3.0",
     "babel-core": "^6.26.3",
@@ -59,7 +60,6 @@
     "rollup": "^0.63.4",
     "rollup-plugin-babel": "^3.0.7",
     "string-to-arraybuffer": "^1.0.2",
-    "url-search-params": "^1.0.2",
     "whatwg-url": "^5.0.0"
   },
   "dependencies": {}

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,7 @@ import then from 'promise';
 import resumer from 'resumer';
 import FormData from 'form-data';
 import stringToArrayBuffer from 'string-to-arraybuffer';
-import URLSearchParams_Polyfill from 'url-search-params';
+import URLSearchParams_Polyfill from '@ungap/url-search-params';
 import { URL } from 'whatwg-url';
 import { AbortController } from 'abortcontroller-polyfill/dist/abortcontroller';
 import AbortController2 from 'abort-controller';


### PR DESCRIPTION
While doing an `npm install`, I saw that the `url-search-params` package is deprecated, and needed to be replaced.  See https://www.npmjs.com/package/url-search-params for more details!