### PR TITLE
build: disable generation of package-lock since it is not used

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
With `package-lock.json` ignored, it's better to just tell `npm` not to generate it at all.  This removes the need for developers on the package to keep deleting `package-lock.json` and re-installing to get the latest patch versions of transitive deps.