### PR TITLE
test: enable --throw-deprecation for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "cross-env BABEL_ENV=rollup rollup -c",
     "prepare": "npm run build",
-    "test": "cross-env BABEL_ENV=test mocha --require babel-register test/test.js",
+    "test": "cross-env BABEL_ENV=test mocha --require babel-register --throw-deprecation test/test.js",
     "report": "cross-env BABEL_ENV=coverage nyc --reporter lcov --reporter text mocha -R spec test/test.js",
     "coverage": "cross-env BABEL_ENV=coverage nyc --reporter json --reporter text mocha -R spec test/test.js && codecov -f coverage/coverage-final.json"
   },


### PR DESCRIPTION
Enabling `--throw-deprecation` for the tests ensures that no deprecated methods are being used in nodejs.  I'm trying to track down a node.js 12 property deprecation, and figured I may as well do this while I was in here :)