### PR TITLE
Issue #588: allow a function supplying the agent to support in follow…

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ The default values are shown after each option key.
     timeout: 0,         // req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies). Signal is recommended instead.
     compress: true,     // support gzip/deflate content encoding. false to disable
     size: 0,            // maximum response body size in bytes. 0 to disable
-    agent: null         // http(s).Agent instance, allows custom proxy, certificate, dns lookup etc.
+    agent: null         // http(s).Agent instance (or function providing one), allows custom proxy, certificate, dns lookup etc.
 }
 ```
 

--- a/src/request.js
+++ b/src/request.js
@@ -230,7 +230,12 @@ export function getNodeRequestOptions(request) {
 		headers.set('Accept-Encoding', 'gzip,deflate');
 	}
 
-	if (!headers.has('Connection') && !request.agent) {
+	let agent = request.agent;
+	if (typeof agent === 'function') {
+		agent = agent(parsedURL);
+	}
+
+	if (!headers.has('Connection') && !agent) {
 		headers.set('Connection', 'close');
 	}
 
@@ -240,6 +245,6 @@ export function getNodeRequestOptions(request) {
 	return Object.assign({}, parsedURL, {
 		method: request.method,
 		headers: exportNodeCompatibleHeaders(headers),
-		agent: request.agent
+		agent
 	});
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1978,6 +1978,30 @@ describe('node-fetch', () => {
 			expect(families[1]).to.equal(family);
 		});
 	});
+
+	it('should allow a function supplying the agent', function() {
+		const url = `${base}inspect`;
+
+		const agent = http.Agent({
+			keepAlive: true
+		});
+
+		let parsedURL;
+
+		return fetch(url, {
+			agent: function(_parsedURL) {
+				parsedURL = _parsedURL;
+				return agent;
+			}
+		}).then(res => {
+			return res.json();
+		}).then(res => {
+			// the agent provider should have been called
+			expect(parsedURL.protocol).to.equal('http:');
+			// the agent we returned should have been used
+			expect(res.headers['connection']).to.equal('keep-alive');
+		});
+	});
 });
 
 describe('Headers', function () {


### PR DESCRIPTION
This PR addresses issue #588. When the user wants to provide an `agent` option, the user has to decide (prior making the call to `fetch`) to provide a http or https agent. If request is for http and makes it redirect to https (or vice versa), the provided `agent` is incompatible and breaks further processing.
Based on the proposal, `agent` can now be a function which takes `parsedURL` as an argument.

A typical use would be:

```js
const httpAgent = new http.Agent({ keepAlive: true });
const httpsAgent = new https.Agent({ keepAlive: true });

const options = {
  agent: url => url.protocol === 'https:' ? httpsAgent : httpAgent
};
```