### PR TITLE
Improve encoding detection for textConverted

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -295,8 +295,8 @@ function convertBody(buffer, headers) {
 		res = /charset=([^;]*)/i.exec(ct);
 	}
 
-	// no charset in content type, peek at response body for at most 1024 bytes
-	str = buffer.slice(0, 1024).toString();
+	// no charset in content type, peek at response body for at most 2048 bytes
+	str = buffer.slice(0, 2048).toString();
 
 	// html5
 	if (!res && str) {


### PR DESCRIPTION
Some websites still use legacy encodings and some of them don't put encoding in `content-type` header.
Also modern websites put ton of `meta` and other things in html `<head>`.

Eg for these 2 articles, encoding meta is not in the first 1024 bytes. And majority of websites with the issue work properly with 2048 bytes, so I believe it's worth looking for encoding meta in the first 2048 bytes, it has very negligible performance impact anyway.

https://www.star.com.tr/medya/game-of-thrones-8-sezon-3-bolum-nasil-izlenir-game-of-thrones-8-sezon-3-bolum-nereden-izlenir-haber-1449578/

http://www.aksam.com.tr/yasam/agaclar-birbirleriyle-nasil-gizlice-iletisim-kuruyor/haber-901490