### PR TITLE
Return null instead of default size for Streams

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -484,7 +484,8 @@ export function getTotalBytes(instance) {
 		return null;
 	} else {
 		// body is stream
-		return instance.size || null;
+		// Since there's no standard way if getting a stream's size before reading it, return nothing.
+		return null;
 	}
 }
 


### PR DESCRIPTION
[This commit](https://github.com/bitinn/node-fetch/commit/0fc414c2a88e897fd941c06734993a1d9a2747e7) introduced a functional regression when sending
readable streams as the body of a fetch request. If the `size` option is
passed into `fetch` and a `Stream` body is present, the `Content-Type`
header is still set to whatever `size` was even though streams don't
have a consistent method for retrieving the size prior to reading them.

To fix this, we can just revert to the previous implementation of
`getTotalBytes`. That change doesn't appear related to the rest of the
commit.