### PR TITLE
Added size option to fileType example of Buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ If you prefer to cache binary data in full, use buffer(). (NOTE: buffer() is a `
 ```js
 const fileType = require('file-type');
 
-fetch('https://assets-cdn.github.com/images/modules/logos_page/Octocat.png')
+fetch('https://assets-cdn.github.com/images/modules/logos_page/Octocat.png', { size: fileType.minimumBytes })
     .then(res => res.buffer())
     .then(buffer => fileType(buffer))
     .then(type => { /* ... */ });


### PR DESCRIPTION
file-type package does not require to read whole file to guess mime type. We can put size option to the request, so example has better quality for readers.