### PR TITLE
Fix 'can only call Window.fetch on instances of Window' error in Safari.

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -13,7 +13,7 @@ var getGlobal = function () {
 
 var global = getGlobal();
 
-module.exports = exports = global.fetch;
+module.exports = exports = global.fetch.bind(global);
 
 // Needed for TypeScript and Webpack.
 exports.default = global.fetch.bind(global);


### PR DESCRIPTION
In Safari, without binding fetch to the global, I get the error:

```
Unhandled Promise Rejection: TypeError: Can only call Window.fetch on instances of Window
```

<img width="649" alt="Screen Shot 2019-06-12 at 1 04 54 AM" src="https://user-images.githubusercontent.com/975687/59324730-2e454300-8cae-11e9-8ad7-e1ddb0c4ee14.png">

It works fine in Chrome. By binding the function to the global, it works in Safari and Chrome.

Thanks.