### PR TITLE
Change error message thrown with redirect mode set to error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,7 @@ export default function fetch(url, opts) {
 				// HTTP fetch step 5.5
 				switch (request.redirect) {
 					case 'error':
-						reject(new FetchError(`redirect mode is set to error: ${request.url}`, 'no-redirect'));
+						reject(new FetchError(`uri requested responds with a redirect, redirect mode is set to error: ${request.url}`, 'no-redirect'));
 						finalize();
 						return;
 					case 'manual':


### PR DESCRIPTION
The original error message does not provide enough information about what went wrong. It simply states a configuration setting.