### PR TITLE
Allow setting custom highWaterMark via node-fetch options (#386)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,37 +12,54 @@ A light-weight module that brings `window.fetch` to Node.js
 
 <!-- TOC -->
 
-- [Motivation](#motivation)
-- [Features](#features)
-- [Difference from client-side fetch](#difference-from-client-side-fetch)
-- [Installation](#installation)
-- [Loading and configuring the module](#loading-and-configuring-the-module)
-- [Common Usage](#common-usage)
-    - [Plain text or HTML](#plain-text-or-html)
-    - [JSON](#json)
-    - [Simple Post](#simple-post)
-    - [Post with JSON](#post-with-json)
-    - [Post with form parameters](#post-with-form-parameters)
-    - [Handling exceptions](#handling-exceptions)
-    - [Handling client and server errors](#handling-client-and-server-errors)
-- [Advanced Usage](#advanced-usage)
-    - [Streams](#streams)
-    - [Buffer](#buffer)
-    - [Accessing Headers and other Meta data](#accessing-headers-and-other-meta-data)
-    - [Extract Set-Cookie Header](#extract-set-cookie-header)
-    - [Post data using a file stream](#post-data-using-a-file-stream)
-    - [Post with form-data (detect multipart)](#post-with-form-data-detect-multipart)
-    - [Request cancellation with AbortSignal](#request-cancellation-with-abortsignal)
-- [API](#api)
+- [node-fetch](#node-fetch)
+  - [Motivation](#motivation)
+  - [Features](#features)
+  - [Difference from client-side fetch](#difference-from-client-side-fetch)
+  - [Installation](#installation)
+  - [Loading and configuring the module](#loading-and-configuring-the-module)
+  - [Common Usage](#common-usage)
+      - [Plain text or HTML](#plain-text-or-html)
+      - [JSON](#json)
+      - [Simple Post](#simple-post)
+      - [Post with JSON](#post-with-json)
+      - [Post with form parameters](#post-with-form-parameters)
+      - [Handling exceptions](#handling-exceptions)
+      - [Handling client and server errors](#handling-client-and-server-errors)
+  - [Advanced Usage](#advanced-usage)
+      - [Streams](#streams)
+      - [Buffer](#buffer)
+      - [Accessing Headers and other Meta data](#accessing-headers-and-other-meta-data)
+      - [Extract Set-Cookie Header](#extract-set-cookie-header)
+      - [Post data using a file stream](#post-data-using-a-file-stream)
+      - [Post with form-data (detect multipart)](#post-with-form-data-detect-multipart)
+      - [Request cancellation with AbortSignal](#request-cancellation-with-abortsignal)
+  - [API](#api)
     - [fetch(url[, options])](#fetchurl-options)
     - [Options](#options)
+        - [Default Headers](#default-headers)
+        - [Custom Agent](#custom-agent)
     - [Class: Request](#class-request)
+      - [new Request(input[, options])](#new-requestinput-options)
     - [Class: Response](#class-response)
+      - [new Response([body[, options]])](#new-responsebody-options)
+      - [response.ok](#responseok)
+      - [response.redirected](#responseredirected)
     - [Class: Headers](#class-headers)
+      - [new Headers([init])](#new-headersinit)
     - [Interface: Body](#interface-body)
+      - [body.body](#bodybody)
+      - [body.bodyUsed](#bodybodyused)
+      - [body.arrayBuffer()](#bodyarraybuffer)
+      - [body.blob()](#bodyblob)
+      - [body.json()](#bodyjson)
+      - [body.text()](#bodytext)
+      - [body.buffer()](#bodybuffer)
+      - [body.textConverted()](#bodytextconverted)
     - [Class: FetchError](#class-fetcherror)
-- [License](#license)
-- [Acknowledgement](#acknowledgement)
+    - [Class: AbortError](#class-aborterror)
+  - [Acknowledgement](#acknowledgement)
+  - [License](#license)
 
 <!-- /TOC -->
 
@@ -319,17 +336,18 @@ The default values are shown after each option key.
 {
     // These properties are part of the Fetch Standard
     method: 'GET',
-    headers: {},        // request headers. format is the identical to that accepted by the Headers constructor (see below)
-    body: null,         // request body. can be null, a string, a Buffer, a Blob, or a Node.js Readable stream
-    redirect: 'follow', // set to `manual` to extract redirect headers, `error` to reject redirect
-    signal: null,       // pass an instance of AbortSignal to optionally abort requests
+    headers: {},            // request headers. format is the identical to that accepted by the Headers constructor (see below)
+    body: null,             // request body. can be null, a string, a Buffer, a Blob, or a Node.js Readable stream
+    redirect: 'follow',     // set to `manual` to extract redirect headers, `error` to reject redirect
+    signal: null,           // pass an instance of AbortSignal to optionally abort requests
 
     // The following properties are node-fetch extensions
-    follow: 20,         // maximum redirect count. 0 to not follow redirect
-    timeout: 0,         // req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies). Signal is recommended instead.
-    compress: true,     // support gzip/deflate content encoding. false to disable
-    size: 0,            // maximum response body size in bytes. 0 to disable
-    agent: null         // http(s).Agent instance or function that returns an instance (see below)
+    follow: 20,             // maximum redirect count. 0 to not follow redirect
+    timeout: 0,             // req/res timeout in ms, it resets on redirect. 0 to disable (OS limit applies). Signal is recommended instead.
+    compress: true,         // support gzip/deflate content encoding. false to disable
+    size: 0,                // maximum response body size in bytes. 0 to disable
+    agent: null             // http(s).Agent instance or function that returns an instance (see below)
+    highWaterMark: 16384    // the maximum number of bytes to store in the internal buffer before ceasing to read from the underlying resource.
 }
 ```
 
@@ -402,6 +420,7 @@ The following node-fetch extension properties are provided:
 - `compress`
 - `counter`
 - `agent`
+- `highWaterMark`
 
 See [options](#fetch-options) for exact meaning of these extensions.
 

--- a/src/body.js
+++ b/src/body.js
@@ -385,10 +385,11 @@ function isBlob(obj) {
 /**
  * Clone body given Res/Req instance
  *
- * @param   Mixed  instance  Response or Request instance
+ * @param   Mixed   instance       Response or Request instance
+ * @param   String  highWaterMark  highWaterMark for both PassThrough body streams
  * @return  Mixed
  */
-export function clone(instance) {
+export function clone(instance, highWaterMark) {
 	let p1;
 	let p2;
 	let {body} = instance;
@@ -402,8 +403,8 @@ export function clone(instance) {
 	// note: we can't clone the form-data object without having it as a dependency
 	if ((body instanceof Stream) && (typeof body.getBoundary !== 'function')) {
 		// Tee instance body
-		p1 = new PassThrough();
-		p2 = new PassThrough();
+		p1 = new PassThrough({highWaterMark});
+		p2 = new PassThrough({highWaterMark});
 		body.pipe(p1);
 		body.pipe(p2);
 		// Set instance body to teed body and return the other teed body

--- a/src/index.js
+++ b/src/index.js
@@ -203,7 +203,8 @@ export default function fetch(url, opts) {
 				headers,
 				size: request.size,
 				timeout: request.timeout,
-				counter: request.counter
+				counter: request.counter,
+				highWaterMark: request.highWaterMark
 			};
 
 			// HTTP-network fetch step 12.1.1.3

--- a/src/request.js
+++ b/src/request.js
@@ -127,6 +127,7 @@ export default class Request {
 				input.compress : true;
 		this.counter = init.counter || input.counter || 0;
 		this.agent = init.agent || input.agent;
+		this.highWaterMark = init.highWaterMark || input.highWaterMark;
 	}
 
 	get method() {

--- a/src/response.js
+++ b/src/response.js
@@ -35,7 +35,8 @@ export default class Response {
 			status,
 			statusText: opts.statusText || '',
 			headers,
-			counter: opts.counter
+			counter: opts.counter,
+			highWaterMark: opts.highWaterMark
 		};
 	}
 
@@ -66,13 +67,17 @@ export default class Response {
 		return this[INTERNALS].headers;
 	}
 
+	get highWaterMark() {
+		return this[INTERNALS].highWaterMark;
+	}
+
 	/**
 	 * Clone this response
 	 *
 	 * @return  Response
 	 */
 	clone() {
-		return new Response(clone(this), {
+		return new Response(clone(this, this.highWaterMark), {
 			url: this.url,
 			status: this.status,
 			statusText: this.statusText,

--- a/test/chai-timeout.js
+++ b/test/chai-timeout.js
@@ -1,0 +1,17 @@
+module.exports = (chai, utils) => {
+	utils.addProperty(chai.Assertion.prototype, 'timeout', function () {
+		return new Promise(resolve => {
+			const timer = setTimeout(() => resolve(true), 150);
+			this._obj.then(() => {
+				clearTimeout(timer);
+				resolve(false);
+			});
+		}).then(timeouted => {
+			this.assert(
+				timeouted,
+				'expected promise to timeout but it was resolved',
+				'expected promise not to timeout but it timed out'
+			);
+		});
+	});
+};

--- a/test/server.js
+++ b/test/server.js
@@ -33,8 +33,22 @@ export default class TestServer {
 		this.server.close(cb);
 	}
 
+	mockResponse(responseHandler) {
+		this.server.nextResponseHandler = responseHandler;
+		return `http://${this.hostname}:${this.port}/mocked`;
+	}
+
 	router(req, res) {
 		const p = parse(req.url).pathname;
+
+		if (p === '/mocked') {
+			if (this.nextResponseHandler) {
+				this.nextResponseHandler(res);
+				this.nextResponseHandler = undefined;
+			} else {
+				throw new Error('No mocked response. Use \'TestServer.mockResponse()\'.');
+			}
+		}
 
 		if (p === '/hello') {
 			res.statusCode = 200;

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,7 @@ import stringToArrayBuffer from 'string-to-arraybuffer';
 import { URL } from 'whatwg-url';
 import { AbortController } from 'abortcontroller-polyfill/dist/abortcontroller';
 import AbortController2 from 'abort-controller';
+import crypto from 'crypto';
 
 // Test subjects
 import fetch, {
@@ -47,9 +48,12 @@ try {
 	convert = require('encoding').convert;
 } catch (error) { }
 
+import chaiTimeout from './chai-timeout';
+
 chai.use(chaiPromised);
 chai.use(chaiIterator);
 chai.use(chaiString);
+chai.use(chaiTimeout);
 const { expect } = chai;
 
 const supportToString = ({
@@ -1754,6 +1758,73 @@ describe('node-fetch', () => {
 			})
 		);
 	});
+
+	// start
+
+		it('should timeout on cloning response without consuming one of the streams when the second packet size is equal default highWaterMark', function () {
+		this.timeout(300);
+		const url = local.mockResponse(res => {
+			// Observed behavior of TCP packets splitting:
+			// - response body size <= 65438 → single packet sent
+			// - response body size  > 65438 → multiple packets sent
+			// Max TCP packet size is 64kB (https://stackoverflow.com/a/2614188/5763764),
+			// but first packet probably transfers more than the response body.
+			const firstPacketMaxSize = 65438;
+			const secondPacketSize = 16 * 1024; // = defaultHighWaterMark
+			res.end(crypto.randomBytes(firstPacketMaxSize + secondPacketSize));
+		});
+		return expect(
+			fetch(url).then(res => res.clone().buffer())
+		).to.timeout;
+	});
+
+	it('should timeout on cloning response without consuming one of the streams when the second packet size is equal custom highWaterMark', function () {
+		this.timeout(300);
+		const url = local.mockResponse(res => {
+			const firstPacketMaxSize = 65438;
+			const secondPacketSize = 10;
+			res.end(crypto.randomBytes(firstPacketMaxSize + secondPacketSize));
+		});
+		return expect(
+			fetch(url, {highWaterMark: 10}).then(res => res.clone().buffer())
+		).to.timeout;
+	});
+
+	it('should not timeout on cloning response without consuming one of the streams when the second packet size is less than default highWaterMark', function () {
+		this.timeout(300);
+		const url = local.mockResponse(res => {
+			const firstPacketMaxSize = 65438;
+			const secondPacketSize = 16 * 1024; // = defaultHighWaterMark
+			res.end(crypto.randomBytes(firstPacketMaxSize + secondPacketSize - 1));
+		});
+		return expect(
+			fetch(url).then(res => res.clone().buffer())
+		).not.to.timeout;
+	});
+
+	it('should not timeout on cloning response without consuming one of the streams when the second packet size is less than custom highWaterMark', function () {
+		this.timeout(300);
+		const url = local.mockResponse(res => {
+			const firstPacketMaxSize = 65438;
+			const secondPacketSize = 10;
+			res.end(crypto.randomBytes(firstPacketMaxSize + secondPacketSize - 1));
+		});
+		return expect(
+			fetch(url, {highWaterMark: 10}).then(res => res.clone().buffer())
+		).not.to.timeout;
+	});
+
+	it('should not timeout on cloning response without consuming one of the streams when the response size is double the custom large highWaterMark - 1', function () {
+		this.timeout(300);
+		const url = local.mockResponse(res => {
+			res.end(crypto.randomBytes(2 * 512 * 1024 - 1));
+		});
+		return expect(
+			fetch(url, {highWaterMark: 512 * 1024}).then(res => res.clone().buffer())
+		).not.to.timeout;
+	});
+
+	// stop
 
 	it('should allow get all responses of a header', () => {
 		const url = `${base}cookie`;


### PR DESCRIPTION
Fixes #386 

This PR uses some bits from #563, but instead of passing the custom highWaterMark to `clone` method, it is passed via node-fetch options:

```diff
- fetch(url).then(res => res.clone(10).buffer());
+ fetch(url, {highWaterMark: 10}).then(res => res.clone().buffer());
```

I used the same tests from #563 to confirm that everything works as expected. However, it would be great if someone could review my changes to check whether I made any mistakes :smile: