### PR TITLE
check for global.fetch before binding it

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -16,7 +16,9 @@ var global = getGlobal();
 module.exports = exports = global.fetch;
 
 // Needed for TypeScript and Webpack.
-exports.default = global.fetch.bind(global);
+if (global.fetch) {
+	exports.default = global.fetch.bind(global);
+}
 
 exports.Headers = global.Headers;
 exports.Request = global.Request;


### PR DESCRIPTION
We ran into some issues where this was executed in browsers that didn't support fetch (e.g. IE11)