### PR TITLE
fix: Properly parse meta tag when parameters are reversed

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -307,7 +307,7 @@ function convertBody(buffer, headers) {
 	if (!res && str) {
 		res = /<meta[\s]+?http-equiv=(['"])content-type\1[\s]+?content=(['"])(.+?)\2/i.exec(str);
 		if (!res) {
-			res = /<meta[\s]+?content=(['"])(.+?)\1[\s]+?http-equiv=(['"])content-type\2/i.exec(str);
+			res = /<meta[\s]+?content=(['"])(.+?)\1[\s]+?http-equiv=(['"])content-type\3/i.exec(str);
 			if (res) {
 				res.pop(); // drop last quote
 			}

--- a/src/body.js
+++ b/src/body.js
@@ -306,6 +306,12 @@ function convertBody(buffer, headers) {
 	// html4
 	if (!res && str) {
 		res = /<meta[\s]+?http-equiv=(['"])content-type\1[\s]+?content=(['"])(.+?)\2/i.exec(str);
+		if (!res) {
+			res = /<meta[\s]+?content=(['"])(.+?)\1[\s]+?http-equiv=(['"])content-type\2/i.exec(str);
+			if (res) {
+				res.pop(); // drop last quote
+			}
+		}
 
 		if (res) {
 			res = /charset=(.*)/i.exec(res.pop());

--- a/test/server.js
+++ b/test/server.js
@@ -181,6 +181,12 @@ export default class TestServer {
 			res.end(convert('<meta http-equiv="Content-Type" content="text/html; charset=gb2312"><div>中文</div>', 'gb2312'));
 		}
 
+		if (p === '/encoding/gb2312-reverse') {
+			res.statusCode = 200;
+			res.setHeader('Content-Type', 'text/html');
+			res.end(convert('<meta content="text/html; charset=gb2312" http-equiv="Content-Type"><div>中文</div>', 'gb2312'));
+		}
+
 		if (p === '/encoding/shift-jis') {
 			res.statusCode = 200;
 			res.setHeader('Content-Type', 'text/html; charset=Shift-JIS');

--- a/test/test.js
+++ b/test/test.js
@@ -2767,6 +2767,16 @@ describe('external encoding', () => {
 			});
 		});
 
+		it('should support encoding decode, html4 detect reverse http-equiv', function() {
+			const url = `${base}encoding/gb2312-reverse`;
+			return fetch(url).then(res => {
+				expect(res.status).to.equal(200);
+				return res.textConverted().then(result => {
+					expect(result).to.equal('<meta content="text/html; charset=gb2312" http-equiv="Content-Type"><div>中文</div>');
+				});
+			});
+		});
+
 		it('should default to utf8 encoding', function() {
 			const url = `${base}encoding/utf8`;
 			return fetch(url).then(res => {


### PR DESCRIPTION
`convertBody`function work fine when html has this meta tag.
`<meta http-equiv="content-type" content="text/html;charset=shift_jis">`

However, if the `http-equiv` attribute is reversed like this, it will not work.
`<meta content="text/html; charset=Shift_JIS" http-equiv="Content-Type" />`
