### PR TITLE
Fix `default` export for webpack

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -17,6 +17,7 @@ module.exports = exports = global.fetch;
 
 // Needed for TypeScript and Webpack.
 if (global.fetch) {
+	Object.defineProperty(exports, "__esModule", { value: true });
 	exports.default = global.fetch.bind(global);
 }
 


### PR DESCRIPTION
When using webpack (e.g. via [CRA](https://create-react-app.dev/)), and importing _node-fetch_ via `import nodeFetch from "node-fetch"`, calling the imported `fetch` function produces the following error.

> Failed to execute 'fetch' on 'Window': Illegal invocation

The reason is that webpack prefers the unbound "function export" (line 16) over the (bound) `exports.default` export (line 20).

Therefore I propose to explicitly mark the `bowser.js` module with `"__esModule" = true`.

This solves the issue because webpack now prefers the bound fetch-function.

See here for details about `__esModule`.
* https://2ality.com/2017/01/babel-esm-spec-mode.html#es-module-imports-are-live-views-of-exports
* https://stackoverflow.com/a/55687758/50890
