### PR TITLE
fix: Throw SyntaxError instead of FetchError in case of invalid JSON

### DIFF
--- a/docs/v3-UPGRADE-GUIDE.md
+++ b/docs/v3-UPGRADE-GUIDE.md
@@ -44,6 +44,17 @@ fetch("https://somewebsite.com").then(res => {
 });
 ```
 
+## JSON parsing errors from `res.json()` are of type `SyntaxError` instead of `FetchError`
+
+When attemping to parse invalid json via `res.json()`, a `SyntaxError` will now be thrown instead of a `FetchError` to align better with the spec.
+
+```js
+const fetch = require("node-fetch");
+
+fetch("https://somewebsitereturninginvalidjson.com").then(res => res.json())
+// Throws 'Uncaught SyntaxError: Unexpected end of JSON input' or similar.
+```
+
 # Enhancements
 
 ## Data URI support

--- a/src/body.js
+++ b/src/body.js
@@ -105,13 +105,7 @@ Body.prototype = {
 	 * @return  Promise
 	 */
 	json() {
-		return consumeBody.call(this).then(buffer => {
-			try {
-				return JSON.parse(buffer.toString());
-			} catch (error) {
-				return Body.Promise.reject(new FetchError(`invalid json response body at ${this.url} reason: ${error.message}`, 'invalid-json'));
-			}
-		});
+		return consumeBody.call(this).then(buffer => JSON.parse(buffer.toString()));
 	},
 
 	/**

--- a/test/test.js
+++ b/test/test.js
@@ -572,9 +572,7 @@ describe('node-fetch', () => {
 		const url = `${base}error/json`;
 		return fetch(url).then(res => {
 			expect(res.headers.get('content-type')).to.equal('application/json');
-			return expect(res.json()).to.eventually.be.rejected
-				.and.be.an.instanceOf(FetchError)
-				.and.include({type: 'invalid-json'});
+			return expect(res.json()).to.eventually.be.rejectedWith(Error);
 		});
 	});
 
@@ -597,9 +595,7 @@ describe('node-fetch', () => {
 			expect(res.status).to.equal(204);
 			expect(res.statusText).to.equal('No Content');
 			expect(res.ok).to.be.true;
-			return expect(res.json()).to.eventually.be.rejected
-				.and.be.an.instanceOf(FetchError)
-				.and.include({type: 'invalid-json'});
+			return expect(res.json()).to.eventually.be.rejectedWith(Error);
 		});
 	});
 


### PR DESCRIPTION
Closes #498.