### PR TITLE
fix: Proper data uri to buffer conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
 		"xo": "^0.25.3"
 	},
 	"dependencies": {
+		"data-uri-to-buffer": "^3.0.0",
 		"fetch-blob": "^1.0.4",
 		"utf8": "^3.0.0"
 	},

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import http from 'http';
 import https from 'https';
 import zlib from 'zlib';
 import Stream, {PassThrough, pipeline as pump} from 'stream';
+import dataURIToBuffer from 'data-uri-to-buffer';
 
 import Body, {writeToStream, getTotalBytes} from './body';
 import Response from './response';
@@ -36,8 +37,8 @@ export default function fetch(url, opts) {
 
 	// If valid data uri
 	if (dataUriRegex.test(url)) {
-		const data = Buffer.from(url.split(',')[1], 'base64');
-		const res = new Response(data.body, {headers: {'Content-Type': data.mimeType || url.match(dataUriRegex)[1] || 'text/plain'}});
+		const data = dataURIToBuffer(url);
+		const res = new Response(data, {headers: {'Content-Type': data.type}});
 		return fetch.Promise.resolve(res);
 	}
 


### PR DESCRIPTION
Turns out, our implementation of data URI to buffer conversion was quite flawed. It always assumed base64 encoding (which wasn't the case when it came to the failing test) and tried to retrieve the non-existent `Buffer.body` property.

I was going to refactor the logic but I realised [`data-uri-to-buffer`](https://www.npmjs.com/package/data-uri-to-buffer) already did **exactly** what we wanted.

\
\
oh and the build is passing WOOO 🎉

cc @bitinn @xxczaki 