### PR TITLE
This patch fixes a problem where not all prototype methods are copied from the Body via the mixin method due to a failure to properly detect properties in the target.

### DIFF
--- a/src/body.js
+++ b/src/body.js
@@ -165,7 +165,7 @@ Object.defineProperties(Body.prototype, {
 Body.mixIn = function (proto) {
 	for (const name of Object.getOwnPropertyNames(Body.prototype)) {
 		// istanbul ignore else: future proof
-		if (!(name in proto)) {
+		if (!proto.hasOwnProperty(name)) {
 			const desc = Object.getOwnPropertyDescriptor(Body.prototype, name);
 			Object.defineProperty(proto, name, desc);
 		}


### PR DESCRIPTION
This patch fixes a problem where not all prototype methods are copied from the Body via the mixin method due to a failure to properly detect properties in the target.  The current code uses the `in` operator, which may return properties lower down the inheritance chain, thus causing them to fail the copy.  The new code properly calls the .hasOwnProperty() method to make the determination