### PR TITLE
do not set ContentLength to NaN

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -212,7 +212,8 @@ export function getNodeRequestOptions(request) {
 	}
 	if (request.body != null) {
 		const totalBytes = getTotalBytes(request);
-		if (typeof totalBytes === 'number') {
+		// set Content-Length if totalBytes is a number (that is not NaN)
+		if (typeof totalBytes === 'number' && totalBytes === totalBytes) {
 			contentLengthValue = String(totalBytes);
 		}
 	}

--- a/src/request.js
+++ b/src/request.js
@@ -213,7 +213,7 @@ export function getNodeRequestOptions(request) {
 	if (request.body != null) {
 		const totalBytes = getTotalBytes(request);
 		// set Content-Length if totalBytes is a number (that is not NaN)
-		if (typeof totalBytes === 'number' && totalBytes === totalBytes) {
+		if (typeof totalBytes === 'number' && !Number.isNaN(totalBytes)) {
 			contentLengthValue = String(totalBytes);
 		}
 	}


### PR DESCRIPTION
node-fetch should take advantage of @naugtur NaN workaround for the form-data package, see https://github.com/form-data/form-data/pull/397#issuecomment-471976669.

form-data package implementation of FormData allows for only two situations: streams of user pre-specified "knownLength" or streams with defined length retrievers (file streams with ends defined, files with sizes on disk, http requests with a content-length), but no concept of a regular old stream with an unknownable length.

naugtur suggests prespecifying the knownLength of such a stream as NaN, which will flow into the calculations and the eventual result of FormData.prototype.getLengthSync.

naugtur notes that this will cause the request package to not set the ContentLength header, and could even be considered a FormData feature.

node-fetch should support this "feature" as well.