### PR TITLE
Fix: Do not set ContentLength to NaN

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -206,7 +206,7 @@ export function getNodeRequestOptions(request) {
 
 	if (request.body != null) {
 		const totalBytes = getTotalBytes(request);
-		// set Content-Length if totalBytes is a number (that is not NaN)
+		// Set Content-Length if totalBytes is a number (that is not NaN)
 		if (typeof totalBytes === 'number' && !Number.isNaN(totalBytes)) {
 			contentLengthValue = String(totalBytes);
 		}

--- a/src/request.js
+++ b/src/request.js
@@ -206,7 +206,8 @@ export function getNodeRequestOptions(request) {
 
 	if (request.body != null) {
 		const totalBytes = getTotalBytes(request);
-		if (typeof totalBytes === 'number') {
+		// set Content-Length if totalBytes is a number (that is not NaN)
+		if (typeof totalBytes === 'number' && !Number.isNaN(totalBytes)) {
 			contentLengthValue = String(totalBytes);
 		}
 	}


### PR DESCRIPTION
As requested within #707, PR for v3 branch.

The underlying "right" thing may be for users of FormData to not have to rely on NaN, but for FormData to support streams of unknowable length out of the box, but it can't hurt for node-fetch to check for NaN in the meantime.

See further discussion (hopefully!) at form-data/form-data#394.